### PR TITLE
Handle skill choice selections in creation preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "node scripts/run-tests.mjs"
   },
   "dependencies": {
     "@pinia/nuxt": "^0.11.2",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,35 @@
+import { build } from 'esbuild';
+import fs from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const projectRoot = path.resolve('.');
+const outDir = path.join(projectRoot, '.tmp-tests');
+const outFile = path.join(outDir, 'creationAdapter.test.mjs');
+
+await fs.rm(outDir, { recursive: true, force: true });
+await fs.mkdir(outDir, { recursive: true });
+
+await build({
+  entryPoints: [path.join(projectRoot, 'tests/creationAdapter.test.ts')],
+  outfile: outFile,
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  sourcemap: 'inline',
+  logLevel: 'silent',
+  alias: {
+    '~': projectRoot,
+    '@': projectRoot
+  }
+});
+
+const mod = await import(pathToFileURL(outFile).href);
+
+if (typeof mod.run === 'function') {
+  await mod.run();
+  await fs.rm(outDir, { recursive: true, force: true });
+} else {
+  console.error('No run() export found in compiled tests');
+  process.exitCode = 1;
+}

--- a/tests/creationAdapter.test.ts
+++ b/tests/creationAdapter.test.ts
@@ -1,52 +1,52 @@
-/**
- * Basic test skeleton for CreationAdapterServer
- * Use your test runner (jest/vitest) to run this file.
- * This test only runs locally if you mock DataAdapterV2GitHub methods.
- */
+import assert from 'node:assert/strict';
 
 import { CreationAdapterServer } from '../utils/creationAdapterServer';
-import { EffectEngine } from '../engine/effectEngine';
 
-class MockAdapter {
-// --- hotfix : utils/creationAdapterServer.ts ---
-async resolveFeatureTree(selection: Selection) {
-  // try adapter first, but be tolerant to errors
-  if (this.adapter && typeof this.adapter.resolveFeatureTree === 'function') {
-    try {
-      const res = await this.adapter.resolveFeatureTree(selection);
-      // defensive: ensure res is array
-      if (Array.isArray(res)) return res;
-      // if adapter returned single object, normalize to array
-      if (res && typeof res === 'object') return [res];
-      // otherwise fall back to local resolution
-      console.warn('[CreationAdapterServer] adapter.resolveFeatureTree returned unexpected value, fallback to local', { res });
-    } catch (err) {
-      // log full error + selection for debugging, then fallback
-      console.error('[CreationAdapterServer] adapter.resolveFeatureTree failed — fallback to local resolution', err, { selection });
-    }
+class StubAdapter {
+  async resolveFeatureTree() {
+    return [
+      {
+        originId: 'race_human',
+        payload: {
+          id: 'race_human',
+          effects: [
+            {
+              type: 'choice',
+              payload: {
+                category: 'skill',
+                ui_id: 'humain_bonus_competence',
+                choose: 1,
+                from: ['survie']
+              }
+            }
+          ]
+        }
+      }
+    ];
   }
-
-  // fallback local resolution (existing logic)
-  const out: any[] = [];
-  if (selection.class) {
-    const cls = await this.readLocalEntity('classes', String(selection.class));
-    if (cls) out.push({ originId: selection.class, payload: cls });
-  }
-  if (selection.race) {
-    const rc = await this.readLocalEntity('races', String(selection.race));
-    if (rc) out.push({ originId: selection.race, payload: rc });
-  }
-  return out;
 }
 
+export async function run() {
+  const adapter = new StubAdapter();
+  const creation = new CreationAdapterServer(adapter as any);
 
-test('applyFeaturesToCharacter applies stat modifier', async () => {
-  const adapter = new MockAdapter();
-  const engine = new EffectEngine();
-  const creation = new CreationAdapterServer(adapter as any, engine);
-  const selection = { race: 'mock_race' };
-  const base = { base_stats_before_race: { dexterity: 10 } };
-  const res = await creation.applyFeaturesToCharacter(selection, base);
-  if (!res.ok) throw new Error('Expected ok');
-  if (res.previewCharacter.final_stats.dexterity !== 12) throw new Error('Expected dex 12');
-});
+  const result = await creation.buildPreview(
+    {
+      chosenOptions: {
+        humain_bonus_competence: ['survie']
+      }
+    },
+    {}
+  );
+
+  assert.equal(result.ok, true, 'preview should be ok');
+  assert.ok(
+    result.previewCharacter.proficiencies.includes('survie'),
+    'selected skill proficiency should be granted'
+  );
+  assert.equal(
+    result.pendingChoices.length,
+    0,
+    'choice should not remain pending when effect generated'
+  );
+}


### PR DESCRIPTION
## Summary
- normalize stored choice selections to string arrays and synthesize proficiency effects for skill choices during preview building
- ensure pending choices persist when no effect is generated while leveraging immediate effects when selections exist
- add a lightweight esbuild-powered test runner and regression test covering human bonus skill selections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d195d28114832ab3f2382240dd84c7