### PR TITLE
Implement catalog endpoints with GitHub adapter fallback

### DIFF
--- a/server/api/catalog/_utils.ts
+++ b/server/api/catalog/_utils.ts
@@ -1,0 +1,124 @@
+import { basename } from 'node:path';
+
+import type { DataAdapterV2GitHub } from '~/utils/dataAdapterV2GitHub';
+import { getCatalogAdapter } from '~/server/utils/catalogAdapter';
+
+type CatalogKind = 'classes' | 'races';
+
+type IndexEntry = string | number | boolean | { [key: string]: any } | null | undefined;
+
+type GitHubEntry = {
+  type?: string;
+  name?: string;
+  path?: string;
+  id?: string;
+  [key: string]: any;
+};
+
+const JSON_EXTENSION = /\.json$/i;
+
+function normalizeIndexEntries(entries: IndexEntry[]): string[] {
+  return entries
+    .map((entry) => {
+      if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+        const value = String(entry).trim();
+        return value.length ? value : null;
+      }
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const candidate = entry.name ?? entry.id ?? null;
+      if (typeof candidate === 'string') {
+        const value = candidate.trim();
+        return value.length ? value : null;
+      }
+      if (candidate != null) {
+        const value = String(candidate).trim();
+        return value.length ? value : null;
+      }
+      return null;
+    })
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function normalizeGitHubEntries(entries: GitHubEntry[]): string[] {
+  return entries
+    .filter((entry) => entry && entry.type === 'file')
+    .map((entry) => {
+      const source =
+        typeof entry.name === 'string'
+          ? entry.name
+          : typeof entry.path === 'string'
+          ? basename(entry.path)
+          : entry.id;
+      if (typeof source !== 'string') {
+        return null;
+      }
+      const cleaned = source.replace(JSON_EXTENSION, '').trim();
+      return cleaned.length ? cleaned : null;
+    })
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function normalizeList(entries: GitHubEntry[] | null | undefined): string[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const onlyJsonFiles = entries.filter((entry) => {
+    if (!entry) {
+      return false;
+    }
+    if (typeof entry.name === 'string') {
+      return JSON_EXTENSION.test(entry.name);
+    }
+    if (typeof entry.path === 'string') {
+      return JSON_EXTENSION.test(entry.path);
+    }
+    return false;
+  });
+  return normalizeGitHubEntries(onlyJsonFiles);
+}
+
+function normalizeIndex(payload: unknown): string[] {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+  return normalizeIndexEntries(payload as IndexEntry[]);
+}
+
+export async function getCatalogLabels(kind: CatalogKind): Promise<string[]> {
+  const adapter: DataAdapterV2GitHub | any = getCatalogAdapter();
+
+  let indexError: unknown = null;
+  let indexPayload: unknown;
+
+  try {
+    indexPayload = await adapter.fetchJsonFromRepoPath(`${kind}/index.json`);
+  } catch (error) {
+    indexError = error;
+  }
+
+  const labelsFromIndex = normalizeIndex(indexPayload);
+  if (labelsFromIndex.length > 0) {
+    return labelsFromIndex;
+  }
+
+  try {
+    const entries = await adapter.listFilesInPath(kind);
+    const labels = normalizeList(entries);
+    if (labels.length > 0) {
+      return labels;
+    }
+  } catch (listError) {
+    if (indexError) {
+      throw Object.assign(new Error(`Failed to load catalog for ${kind}`), { cause: { indexError, listError } });
+    }
+    throw listError;
+  }
+
+  if (indexError) {
+    throw indexError instanceof Error ? indexError : new Error(String(indexError));
+  }
+
+  return [];
+}

--- a/server/api/catalog/classes.get.ts
+++ b/server/api/catalog/classes.get.ts
@@ -1,0 +1,10 @@
+import { getCatalogLabels } from './_utils';
+
+export default defineEventHandler(async () => {
+  try {
+    return await getCatalogLabels('classes');
+  } catch (error) {
+    console.error('[catalog/classes] failed to load catalog', error);
+    return [];
+  }
+});

--- a/server/api/catalog/races.get.ts
+++ b/server/api/catalog/races.get.ts
@@ -1,0 +1,10 @@
+import { getCatalogLabels } from './_utils';
+
+export default defineEventHandler(async () => {
+  try {
+    return await getCatalogLabels('races');
+  } catch (error) {
+    console.error('[catalog/races] failed to load catalog', error);
+    return [];
+  }
+});

--- a/server/utils/catalogAdapter.ts
+++ b/server/utils/catalogAdapter.ts
@@ -1,0 +1,34 @@
+import { DataAdapterV2GitHub } from '~/utils/dataAdapterV2GitHub';
+
+let adapterSingleton: any = null;
+
+function resolveRuntimeConfig() {
+  try {
+    if (typeof useRuntimeConfig === 'function') {
+      return useRuntimeConfig();
+    }
+  } catch (error) {
+    // ignore runtime config resolution errors, fallback to env vars below
+  }
+  return {} as any;
+}
+
+export function getCatalogAdapter() {
+  if (adapterSingleton) {
+    return adapterSingleton;
+  }
+
+  const config = resolveRuntimeConfig() as any;
+  const owner = config.github?.owner || process.env.GITHUB_OWNER || 'Ocytowine';
+  const repo = config.github?.repo || process.env.GITHUB_REPO || 'ArchiveValmorinTest';
+  const branch = config.github?.branch || process.env.GITHUB_BRANCH || 'main';
+  const token = config.github?.token || process.env.GITHUB_TOKEN || '';
+  const cacheDir = config.dataCacheDir || process.env.DATA_CACHE_DIR || '/tmp/data_adapter_cache';
+
+  adapterSingleton = new DataAdapterV2GitHub(owner, repo, { branch, token, cacheDir });
+  return adapterSingleton;
+}
+
+export function setCatalogAdapter(adapter: any) {
+  adapterSingleton = adapter;
+}

--- a/tests/catalogHandlers.test.ts
+++ b/tests/catalogHandlers.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+
+import { setCatalogAdapter } from '../server/utils/catalogAdapter';
+
+class SuccessAdapter {
+  async fetchJsonFromRepoPath(repoPath: string) {
+    if (repoPath === 'classes/index.json') {
+      return ['Guerrier', { name: 'Mage' }, { id: 'roublard' }, 42, null];
+    }
+    if (repoPath === 'races/index.json') {
+      return [{ name: 'Humain' }, { id: 'elfe' }, 'nain'];
+    }
+    throw new Error(`unexpected path: ${repoPath}`);
+  }
+
+  async listFilesInPath() {
+    throw new Error('listFilesInPath should not be called in success scenario');
+  }
+}
+
+class FallbackAdapter {
+  async fetchJsonFromRepoPath() {
+    throw new Error('index not available');
+  }
+
+  async listFilesInPath(kind: string) {
+    if (kind === 'races') {
+      return [
+        { type: 'file', name: 'elfe.json' },
+        { type: 'dir', name: 'subfolder' },
+        { type: 'file', path: 'races/nain.json' }
+      ];
+    }
+    if (kind === 'classes') {
+      return [
+        { type: 'file', name: 'barbare.json' },
+        { type: 'file', name: 'barde.JSON' },
+        { type: 'file', path: 'classes/ensorceleur.json' }
+      ];
+    }
+    return [];
+  }
+}
+
+class ErroringAdapter {
+  async fetchJsonFromRepoPath() {
+    throw new Error('cannot fetch index');
+  }
+
+  async listFilesInPath() {
+    throw new Error('cannot list files');
+  }
+}
+
+export async function run() {
+  const originalDefine = (globalThis as any).defineEventHandler;
+  const originalConfig = (globalThis as any).useRuntimeConfig;
+
+  (globalThis as any).defineEventHandler = (handler: any) => handler;
+  (globalThis as any).useRuntimeConfig = () => ({ github: {}, dataCacheDir: '/tmp/test-cache' });
+
+  const classesModule = await import('../server/api/catalog/classes.get');
+  const racesModule = await import('../server/api/catalog/races.get');
+  const classesHandler = classesModule.default;
+  const racesHandler = racesModule.default;
+
+  setCatalogAdapter(new SuccessAdapter());
+  const classesFromIndex = await classesHandler({} as any);
+  const racesFromIndex = await racesHandler({} as any);
+
+  assert.deepEqual(classesFromIndex, ['Guerrier', 'Mage', 'roublard', '42']);
+  assert.deepEqual(racesFromIndex, ['Humain', 'elfe', 'nain']);
+
+  setCatalogAdapter(new FallbackAdapter());
+  const classesFallback = await classesHandler({} as any);
+  const racesFallback = await racesHandler({} as any);
+
+  assert.deepEqual(classesFallback, ['barbare', 'barde', 'ensorceleur']);
+  assert.deepEqual(racesFallback, ['elfe', 'nain']);
+
+  const originalError = console.error;
+  let loggedErrors = 0;
+  console.error = (...args: any[]) => {
+    loggedErrors += 1;
+    return originalError.apply(console, args as any);
+  };
+
+  setCatalogAdapter(new ErroringAdapter());
+  const classesError = await classesHandler({} as any);
+  const racesError = await racesHandler({} as any);
+
+  assert.deepEqual(classesError, []);
+  assert.deepEqual(racesError, []);
+  assert.ok(loggedErrors >= 2, 'errors should be logged for each catalog handler');
+
+  console.error = originalError;
+  setCatalogAdapter(null);
+
+  if (originalDefine) {
+    (globalThis as any).defineEventHandler = originalDefine;
+  } else {
+    delete (globalThis as any).defineEventHandler;
+  }
+
+  if (originalConfig) {
+    (globalThis as any).useRuntimeConfig = originalConfig;
+  } else {
+    delete (globalThis as any).useRuntimeConfig;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable server-side catalog adapter helper wired to runtime configuration
- fetch catalog entries for classes and races with JSON index support and file listing fallback
- cover the new handlers with tests and extend the test runner to execute every test module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d281dcbeec832aa96929d9bd1e0150