### PR TITLE
feat: support auto_from choices in creation adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,31 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## Creation adapter helper
+
+When configuring server-side creation flows you can now leverage dynamic collections through the `auto_from` helper on choice
+effects. This helper queries the underlying data adapter (for example the GitHub adapter) to populate available options without
+hard-coding identifiers in the effect payload.
+
+```jsonc
+{
+  "type": "choice",
+  "payload": {
+    "category": "spell",
+    "ui_id": "wizard_level1_spell",
+    "choose": 1,
+    "auto_from": {
+      "collection": "spells",
+      "filters": {
+        "level": 1,
+        "tags": ["wizard"]
+      }
+    }
+  }
+}
+```
+
+Each entry returned by the adapter must expose the fields used by the filters (e.g. `level`, `school`, `tags`). The creation
+adapter automatically resolves the matching entries, converts them into `{ id, label }` pairs, and stores them in the pending
+choice descriptor (`from` / `from_labels`).


### PR DESCRIPTION
## Summary
- hydrate pending choices with dynamic options when `auto_from` is set, including a helper on the creation adapter server
- add a cached `queryCollection` helper to the GitHub data adapter for filtering collections
- document and test the new spell selection flow driven by `auto_from`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d29288d534832aa89655db2b9eb629