### PR TITLE
Handle spell choice effects in creation adapter

### DIFF
--- a/tests/creationAdapter.test.ts
+++ b/tests/creationAdapter.test.ts
@@ -112,4 +112,25 @@ export async function run() {
     [{ id: 'spell_magic_missile', label: 'Projectiles magiques' }],
     'auto_from should provide labels for filtered spells'
   );
+
+  const resultWithSpell = await creation.buildPreview(
+    {
+      chosenOptions: {
+        humain_bonus_competence: ['survie'],
+        wizard_level1_spell: ['spell_magic_missile']
+      }
+    },
+    {}
+  );
+
+  assert.equal(resultWithSpell.ok, true, 'preview with spell selection should be ok');
+  assert.equal(
+    resultWithSpell.pendingChoices.length,
+    0,
+    'all choices should be satisfied when spell is preselected'
+  );
+  assert.ok(
+    resultWithSpell.previewCharacter.spellcasting?.known?.includes('spell_magic_missile'),
+    'selected spell should be granted to known spells'
+  );
 }

--- a/utils/creationAdapterServer.ts
+++ b/utils/creationAdapterServer.ts
@@ -183,6 +183,19 @@ export class CreationAdapterServer {
                   effectGenerated = true;
                 }
 
+                if ((category === 'spell' || category === 'spells') && chosenIds.length > 0) {
+                  for (const spellId of chosenIds) {
+                    immediateEffects.push({
+                      source: node.originId ?? payloadEntity.id ?? null,
+                      effect: {
+                        type: 'spell_grant',
+                        payload: { spell_id: spellId }
+                      }
+                    });
+                  }
+                  effectGenerated = true;
+                }
+
                 if (!effectGenerated) {
                   await this.addPendingChoice(pendingChoices, cd);
                 }


### PR DESCRIPTION
## Summary
- convert spell category choices with selected options into spell_grant effects so they apply immediately
- avoid re-queueing satisfied choices when effects are generated
- cover spell selection handling in the creation adapter test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2adeaa53c832aa48300c33b5abd38