### PR TITLE
Refactor wizard selections with catalog metadata

### DIFF
--- a/server/api/catalog/_utils.ts
+++ b/server/api/catalog/_utils.ts
@@ -3,7 +3,14 @@ import { basename } from 'node:path';
 import type { DataAdapterV2GitHub } from '~/utils/dataAdapterV2GitHub';
 import { getCatalogAdapter } from '~/server/utils/catalogAdapter';
 
-type CatalogKind = 'classes' | 'races';
+export type CatalogEntry = {
+  id: string;
+  name: string;
+  description: string | null;
+  image: string | null;
+};
+
+type CatalogKind = 'classes' | 'races' | 'backgrounds';
 
 type IndexEntry = string | number | boolean | { [key: string]: any } | null | undefined;
 
@@ -16,108 +23,182 @@ type GitHubEntry = {
 };
 
 const JSON_EXTENSION = /\.json$/i;
+const TEXT_FIELDS = ['description', 'desc', 'summary', 'flavor', 'flavor_text', 'text'];
+const IMAGE_FIELDS = ['image', 'img', 'icon', 'art', 'avatar', 'illustration', 'picture', 'thumbnail'];
 
-function normalizeIndexEntries(entries: IndexEntry[]): string[] {
-  return entries
-    .map((entry) => {
-      if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
-        const value = String(entry).trim();
-        return value.length ? value : null;
+const pickFirstString = (values: Array<unknown>): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length) {
+        return trimmed;
       }
-      if (!entry || typeof entry !== 'object') {
-        return null;
-      }
-      const candidate = entry.name ?? entry.id ?? null;
-      if (typeof candidate === 'string') {
-        const value = candidate.trim();
-        return value.length ? value : null;
-      }
-      if (candidate != null) {
-        const value = String(candidate).trim();
-        return value.length ? value : null;
-      }
-      return null;
-    })
-    .filter((value): value is string => typeof value === 'string' && value.length > 0);
-}
-
-function normalizeGitHubEntries(entries: GitHubEntry[]): string[] {
-  return entries
-    .filter((entry) => entry && entry.type === 'file')
-    .map((entry) => {
-      const source =
-        typeof entry.name === 'string'
-          ? entry.name
-          : typeof entry.path === 'string'
-          ? basename(entry.path)
-          : entry.id;
-      if (typeof source !== 'string') {
-        return null;
-      }
-      const cleaned = source.replace(JSON_EXTENSION, '').trim();
-      return cleaned.length ? cleaned : null;
-    })
-    .filter((value): value is string => typeof value === 'string' && value.length > 0);
-}
-
-function normalizeList(entries: GitHubEntry[] | null | undefined): string[] {
-  if (!Array.isArray(entries)) {
-    return [];
+    }
   }
-  const onlyJsonFiles = entries.filter((entry) => {
-    if (!entry) {
-      return false;
-    }
-    if (typeof entry.name === 'string') {
-      return JSON_EXTENSION.test(entry.name);
-    }
-    if (typeof entry.path === 'string') {
-      return JSON_EXTENSION.test(entry.path);
-    }
-    return false;
-  });
-  return normalizeGitHubEntries(onlyJsonFiles);
-}
+  return null;
+};
 
-function normalizeIndex(payload: unknown): string[] {
+const toSlug = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const asString = String(value).trim();
+  if (!asString.length) {
+    return null;
+  }
+  const withoutJson = asString.replace(JSON_EXTENSION, '');
+  const segments = withoutJson.split('/');
+  const slug = segments[segments.length - 1]?.trim();
+  return slug && slug.length ? slug : null;
+};
+
+const humanizeLabel = (value: string): string => {
+  const normalized = value.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalized.length) {
+    return value;
+  }
+  return normalized.replace(/\b(\p{L})(\p{L}*)/gu, (_, first: string, rest: string) => `${first.toUpperCase()}${rest.toLowerCase()}`);
+};
+
+const fromIndexEntry = (entry: IndexEntry, idx: number): CatalogEntry | null => {
+  if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+    const id = toSlug(entry);
+    if (!id) {
+      return null;
+    }
+    return {
+      id,
+      name: humanizeLabel(id),
+      description: null,
+      image: null
+    };
+  }
+
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const record = entry as Record<string, any>;
+  const id =
+    toSlug(record.id) ??
+    toSlug(record.slug) ??
+    toSlug(record.uid) ??
+    toSlug(record.key) ??
+    toSlug(record.value) ??
+    toSlug(record.name) ??
+    `entry_${idx}`;
+
+  if (!id) {
+    return null;
+  }
+
+  const name = pickFirstString([record.label, record.name, record.title, record.text]) ?? humanizeLabel(id);
+  const description = pickFirstString(TEXT_FIELDS.map((field) => record[field]));
+  const image = pickFirstString(IMAGE_FIELDS.map((field) => record[field]));
+
+  return {
+    id,
+    name,
+    description: description ?? null,
+    image: image ?? null
+  };
+};
+
+const normalizeIndex = (payload: unknown): CatalogEntry[] => {
   if (!Array.isArray(payload)) {
     return [];
   }
-  return normalizeIndexEntries(payload as IndexEntry[]);
-}
 
-export async function getCatalogLabels(kind: CatalogKind): Promise<string[]> {
+  const entries = new Map<string, CatalogEntry>();
+  payload.forEach((item, idx) => {
+    const normalized = fromIndexEntry(item as IndexEntry, idx);
+    if (normalized) {
+      entries.set(normalized.id, normalized);
+    }
+  });
+
+  return Array.from(entries.values());
+};
+
+const fromGitHubEntry = (entry: GitHubEntry): CatalogEntry | null => {
+  if (!entry || entry.type !== 'file') {
+    return null;
+  }
+
+  const source =
+    typeof entry.name === 'string'
+      ? entry.name
+      : typeof entry.path === 'string'
+      ? basename(entry.path)
+      : entry.id;
+
+  if (typeof source !== 'string') {
+    return null;
+  }
+
+  const id = toSlug(source);
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    name: humanizeLabel(id),
+    description: null,
+    image: null
+  };
+};
+
+const normalizeList = (entries: GitHubEntry[] | null | undefined): CatalogEntry[] => {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const output = new Map<string, CatalogEntry>();
+  entries.forEach((entry) => {
+    const normalized = fromGitHubEntry(entry);
+    if (normalized) {
+      output.set(normalized.id, normalized);
+    }
+  });
+  return Array.from(output.values());
+};
+
+export async function getCatalogEntries(kind: CatalogKind): Promise<CatalogEntry[]> {
   const adapter: DataAdapterV2GitHub | any = getCatalogAdapter();
+  if (!adapter) {
+    console.error(`[catalog] Aucun adaptateur configuré pour ${kind}`);
+    return [];
+  }
 
   let indexError: unknown = null;
-  let indexPayload: unknown;
 
   try {
-    indexPayload = await adapter.fetchJsonFromRepoPath(`${kind}/index.json`);
+    const payload = await adapter.fetchJsonFromRepoPath(`${kind}/index.json`);
+    const normalized = normalizeIndex(payload);
+    if (normalized.length) {
+      return normalized;
+    }
   } catch (error) {
     indexError = error;
   }
 
-  const labelsFromIndex = normalizeIndex(indexPayload);
-  if (labelsFromIndex.length > 0) {
-    return labelsFromIndex;
-  }
-
   try {
     const entries = await adapter.listFilesInPath(kind);
-    const labels = normalizeList(entries);
-    if (labels.length > 0) {
-      return labels;
+    const normalized = normalizeList(entries);
+    if (normalized.length) {
+      return normalized;
     }
   } catch (listError) {
     if (indexError) {
-      throw Object.assign(new Error(`Failed to load catalog for ${kind}`), { cause: { indexError, listError } });
+      console.error(`[catalog] Impossible de charger le catalogue ${kind}`, { indexError, listError });
+      return [];
     }
-    throw listError;
+    console.error(`[catalog] Impossible de lister les fichiers pour ${kind}`, listError);
+    return [];
   }
 
   if (indexError) {
-    throw indexError instanceof Error ? indexError : new Error(String(indexError));
+    console.error(`[catalog] Index introuvable pour ${kind}`, indexError);
   }
 
   return [];

--- a/server/api/catalog/backgrounds.get.ts
+++ b/server/api/catalog/backgrounds.get.ts
@@ -1,0 +1,10 @@
+import { getCatalogEntries } from './_utils';
+
+export default defineEventHandler(async () => {
+  try {
+    return await getCatalogEntries('backgrounds');
+  } catch (error) {
+    console.error('[catalog/backgrounds] failed to load catalog', error);
+    return [];
+  }
+});

--- a/server/api/catalog/classes.get.ts
+++ b/server/api/catalog/classes.get.ts
@@ -1,8 +1,8 @@
-import { getCatalogLabels } from './_utils';
+import { getCatalogEntries } from './_utils';
 
 export default defineEventHandler(async () => {
   try {
-    return await getCatalogLabels('classes');
+    return await getCatalogEntries('classes');
   } catch (error) {
     console.error('[catalog/classes] failed to load catalog', error);
     return [];

--- a/server/api/catalog/races.get.ts
+++ b/server/api/catalog/races.get.ts
@@ -1,8 +1,8 @@
-import { getCatalogLabels } from './_utils';
+import { getCatalogEntries } from './_utils';
 
 export default defineEventHandler(async () => {
   try {
-    return await getCatalogLabels('races');
+    return await getCatalogEntries('races');
   } catch (error) {
     console.error('[catalog/races] failed to load catalog', error);
     return [];


### PR DESCRIPTION
## Summary
- switch the wizard to card-based selectors for class, race, and the new mandatory background using placeholder imagery and descriptions
- update pending-choice interactions to use the same horizontal cards with metadata-aware toggles and ensure preview requests include the chosen background
- return structured catalog entries with names, descriptions, and images for classes, races, and backgrounds while expanding catalog handler tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d395b324e0832a8d8116e0e1d84715