### PR TITLE
Fix spells catalog handler import

### DIFF
--- a/server/api/catalog/_utils.ts
+++ b/server/api/catalog/_utils.ts
@@ -9,7 +9,7 @@ export type CatalogEntry = {
   description: string | null;
   image: string | null;
 };
-type CatalogKind = 'classes' | 'races' | 'backgrounds';
+type CatalogKind = 'classes' | 'races' | 'backgrounds' | 'spells';
 
 type IndexEntry = string | number | boolean | { [key: string]: any } | null | undefined;
 

--- a/server/api/catalog/spells.get.ts
+++ b/server/api/catalog/spells.get.ts
@@ -1,8 +1,8 @@
-import { getCatalogLabels } from './_utils';
+import { getCatalogEntries } from './_utils';
 
 export default defineEventHandler(async () => {
   try {
-    return await getCatalogLabels('classes');
+    return await getCatalogEntries('spells');
   } catch (error) {
     console.error('[catalog/classes] failed to load catalog', error);
     return [];


### PR DESCRIPTION
## Summary
- export catalog utilities for the spells collection
- align the spells catalog API handler with the shared catalog entry helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3bcace7d4832a9b1ecee4675ae2bf