### PR TITLE
Fix duplicate ChoiceOption type declaration

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -536,8 +536,6 @@ const localChosen = reactive<Record<string, any>>({});
 const choiceOptionCache = reactive<Record<string, ChoiceOption[]>>({});
 const choiceMetadata = reactive<Record<string, { label: string }>>({});
 
-type ChoiceOption = { value: any; label: string; description?: string; image?: string };
-
 const extractChoiceFrom = (choice: any): any[] => {
   if (Array.isArray(choice?.from) && choice.from.length) {
     return choice.from;


### PR DESCRIPTION
## Summary
- remove the duplicate ChoiceOption type alias introduced near the bottom of BonomeWizard.vue
- rely on the existing ChoiceOption definition declared earlier in the script setup block to prevent Vite type redeclaration errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c031f2e8832a99193b0621785760