### PR TITLE
Refactor creation wizard layout with preview column

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -1,90 +1,106 @@
 <template>
-  <div class="p-4 max-w-4xl mx-auto">
+  <div class="p-4 max-w-6xl mx-auto">
     <h2 class="text-2xl font-semibold mb-4">Création de personnage — Wizard (light)</h2>
 
-    <!-- Sélections -->
-    <section class="mb-6 border rounded p-4 bg-white/80">
+    <div
+      class="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]"
+    >
       <div class="space-y-6">
-        <div
-          v-for="group in primarySelectionGroups"
-          :key="group.id"
-
-          class="border border-slate-200/70 rounded-xl p-4 bg-white shadow-sm"
-        >
-          <div class="flex items-center justify-between mb-3">
-            <div>
-              <h3 class="text-lg font-semibold">{{ group.title }}</h3>
-              <p class="text-sm text-gray-600">Choisir une option obligatoire.</p>
-            </div>
-            <span class="text-xs uppercase tracking-wide text-gray-500">1 sélection</span>
-          </div>
-
-          <div v-if="group.options.length" class="-mx-1 px-1">
+        <!-- Sélections -->
+        <section class="border rounded p-4 bg-white/80">
+          <div class="space-y-6">
             <div
-              class="grid grid-flow-col auto-cols-[minmax(18rem,1fr)] lg:auto-cols-[18rem] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+              v-for="group in primarySelectionGroups"
+              :key="group.id"
+
+              class="border border-slate-200/70 rounded-xl p-4 bg-white shadow-sm"
             >
-              <button
-                v-for="option in group.options"
-                :key="option.id"
-                type="button"
-
-                class="snap-center w-full rounded-xl border border-slate-200 bg-white p-3 text-left shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-
-                :class="{
-                  'ring-2 ring-blue-500 border-blue-500 shadow-md': group.selected === option.id
-                }"
-                :aria-pressed="group.selected === option.id"
-                @click="selectPrimaryOption(group.id, option.id)"
-              >
-                <div class="h-32 w-full overflow-hidden rounded-lg bg-slate-200">
-                  <img
-                    :src="option.image"
-                    :alt="`Illustration ${option.label}`"
-                    class="h-full w-full object-cover"
-                    loading="lazy"
-                  />
+              <div class="flex items-center justify-between mb-3">
+                <div>
+                  <h3 class="text-lg font-semibold">{{ group.title }}</h3>
+                  <p class="text-sm text-gray-600">Choisir une option obligatoire.</p>
                 </div>
-                <div class="mt-3 space-y-1">
-                  <div class="text-base font-medium text-slate-900">{{ option.label }}</div>
-                  <div class="text-sm leading-snug text-gray-600 min-h-[3.5rem]">{{ option.description }}</div>
+                <span class="text-xs uppercase tracking-wide text-gray-500">1 sélection</span>
+              </div>
+
+              <div v-if="group.options.length" class="-mx-1 px-1">
+                <div
+                  class="grid grid-flow-col auto-cols-[minmax(18rem,1fr)] lg:auto-cols-[18rem] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+                >
+                  <button
+                    v-for="option in group.options"
+                    :key="option.id"
+                    type="button"
+
+                    class="snap-center w-full rounded-xl border border-slate-200 bg-white p-3 text-left shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+
+                    :class="{
+                      'ring-2 ring-blue-500 border-blue-500 shadow-md': group.selected === option.id
+                    }"
+                    :aria-pressed="group.selected === option.id"
+                    @click="selectPrimaryOption(group.id, option.id)"
+                  >
+                    <div class="h-32 w-full overflow-hidden rounded-lg bg-slate-200">
+                      <img
+                        :src="option.image"
+                        :alt="`Illustration ${option.label}`"
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    </div>
+                    <div class="mt-3 space-y-3">
+                      <div>
+                        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Nom</div>
+                        <div class="text-base font-medium text-slate-900">{{ option.label }}</div>
+                      </div>
+                      <div>
+                        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Description</div>
+                        <p class="text-sm leading-snug text-gray-600 min-h-[3.5rem]">{{ option.description }}</p>
+                      </div>
+                    </div>
+                  </button>
                 </div>
-              </button>
+              </div>
+              <div v-else class="text-sm text-gray-500">Aucune option disponible pour l'instant.</div>
+
+              <div class="mt-3 text-sm text-gray-600">
+                Option sélectionnée :
+                <span class="font-medium">{{ getPrimarySelectedLabel(group) }}</span>
+              </div>
+            </div>
+
+            <div class="grid gap-3 md:grid-cols-2">
+              <div>
+                <label class="block text-sm font-medium mb-1">Niveau</label>
+                <input type="number" v-model.number="niveau" min="1" max="20" class="w-full border rounded p-2" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Nom du personnage</label>
+                <input type="text" v-model="characterName" placeholder="Nom personnalisé" class="w-full border rounded p-2" />
+              </div>
             </div>
           </div>
-          <div v-else class="text-sm text-gray-500">Aucune option disponible pour l'instant.</div>
 
-          <div class="mt-3 text-sm text-gray-600">
-            Option sélectionnée :
-            <span class="font-medium">{{ getPrimarySelectedLabel(group) }}</span>
+          <hr class="my-3" />
+
+          <!-- Base stats quick edit -->
+          <div class="grid grid-cols-3 md:grid-cols-6 gap-2">
+            <div v-for="(v,k) in baseStats" :key="k">
+              <label class="block text-xs text-gray-600">{{ k }}</label>
+              <input type="number" v-model.number="baseStats[k]" class="w-full border rounded p-1" />
+            </div>
           </div>
-        </div>
 
-        <div>
-          <label class="block text-sm font-medium mb-1">Niveau</label>
-          <input type="number" v-model.number="niveau" min="1" max="20" class="w-full border rounded p-2" />
-        </div>
-      </div>
+          <div class="mt-4 flex flex-wrap gap-2">
+            <button @click="sendPreview" :disabled="loading" class="px-3 py-2 rounded bg-blue-600 text-white">
+              {{ loading ? 'Prévisualisation...' : 'Prévisualiser' }}
+            </button>
+            <button @click="resetChosenOptions" class="px-3 py-2 rounded border">Réinitialiser choix</button>
+          </div>
+        </section>
 
-      <hr class="my-3" />
-
-      <!-- Base stats quick edit -->
-      <div class="grid grid-cols-3 md:grid-cols-6 gap-2">
-        <div v-for="(v,k) in baseStats" :key="k">
-          <label class="block text-xs text-gray-600">{{ k }}</label>
-          <input type="number" v-model.number="baseStats[k]" class="w-full border rounded p-1" />
-        </div>
-      </div>
-
-      <div class="mt-4 flex gap-2">
-        <button @click="sendPreview" :disabled="loading" class="px-3 py-2 rounded bg-blue-600 text-white">
-          {{ loading ? 'Prévisualisation...' : 'Prévisualiser' }}
-        </button>
-        <button @click="resetChosenOptions" class="px-3 py-2 rounded border">Réinitialiser choix</button>
-      </div>
-    </section>
-
-    <!-- Pending choices -->
-    <section v-if="preview && preview.pendingChoices && preview.pendingChoices.length" class="mb-6 p-4 border rounded bg-white/80">
+        <!-- Pending choices -->
+        <section v-if="preview && preview.pendingChoices && preview.pendingChoices.length" class="p-4 border rounded bg-white/80">
       <h3 class="font-semibold mb-2">Choix à faire</h3>
       <div
         v-for="(choice, idx) in preview.pendingChoices"
@@ -131,10 +147,16 @@
                       loading="lazy"
                     />
                   </div>
-                  <div class="mt-3 space-y-1">
-                    <div class="text-base font-medium text-slate-900">{{ opt.label }}</div>
-                    <div class="text-sm leading-snug text-gray-600 min-h-[3.5rem]">
-                      {{ getChoiceOptionDescription(opt) }}
+                  <div class="mt-3 space-y-3">
+                    <div>
+                      <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Nom</div>
+                      <div class="text-base font-medium text-slate-900">{{ opt.label }}</div>
+                    </div>
+                    <div>
+                      <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Description</div>
+                      <p class="text-sm leading-snug text-gray-600 min-h-[3.5rem]">
+                        {{ getChoiceOptionDescription(opt) }}
+                      </p>
                     </div>
                   </div>
                 </button>
@@ -166,117 +188,164 @@
       </div>
     </section>
 
-    <!-- Applied choices overview -->
-    <section
-      v-if="appliedChoices.length"
-      class="mb-6 p-4 border rounded bg-white/80"
-    >
-      <h3 class="font-semibold mb-2">Choix appliqués</h3>
-      <ul class="space-y-2">
-        <li
-          v-for="choice in appliedChoices"
-          :key="choice.id"
-          class="flex items-start justify-between gap-4 border rounded p-3 bg-white"
-        >
-          <div>
-            <div class="font-medium">{{ choice.label }}</div>
-            <div class="text-sm text-gray-600">{{ choice.displayValue }}</div>
-          </div>
-          <button @click="resetChoiceById(choice.id)" class="px-3 py-1 rounded border">Réinitialiser</button>
-        </li>
-      </ul>
-    </section>
+        <!-- Applied choices overview -->
+        <section v-if="appliedChoices.length" class="p-4 border rounded bg-white/80">
+          <h3 class="font-semibold mb-2">Choix appliqués</h3>
+          <ul class="space-y-2">
+            <li
+              v-for="choice in appliedChoices"
+              :key="choice.id"
+              class="flex items-start justify-between gap-4 border rounded p-3 bg-white"
+            >
+              <div>
+                <div class="font-medium">{{ choice.label }}</div>
+                <div class="text-sm text-gray-600">{{ choice.displayValue }}</div>
+              </div>
+              <button @click="resetChoiceById(choice.id)" class="px-3 py-1 rounded border">Réinitialiser</button>
+            </li>
+          </ul>
+        </section>
 
-    <!-- Preview area -->
-    <section v-if="preview" class="mb-6 p-4 border rounded bg-white/80">
-      <div class="flex items-start justify-between">
-        <h3 class="text-lg font-semibold">Preview</h3>
-        <div class="text-sm text-gray-600">applied: {{ preview.appliedFeatures?.length ?? 0 }}</div>
+        <!-- Raw response debug -->
+        <section class="p-4 border rounded bg-white/80">
+          <button @click="showRaw = !showRaw" class="px-3 py-1 rounded border">
+            {{ showRaw ? 'Cacher Raw response (debug)' : 'Voir Raw response (debug)' }}
+          </button>
+          <div v-if="showRaw" class="mt-3">
+            <pre class="whitespace-pre-wrap bg-slate-100 p-3 rounded text-sm overflow-auto" style="max-height:400px">{{ rawText }}</pre>
+          </div>
+        </section>
       </div>
 
-      <div class="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
-        <!-- Left: stats & proficiencies -->
-        <div class="border rounded p-3 bg-white">
-          <h4 class="font-medium mb-2">Caractéristiques</h4>
-          <table class="w-full text-sm">
-            <tr v-for="(val, key) in displayStats" :key="key">
-              <td class="pr-3 font-medium">{{ key }}</td>
-              <td>{{ val }}</td>
-            </tr>
-          </table>
+      <div class="space-y-6">
+        <!-- Preview area -->
+        <section v-if="preview" class="p-4 border rounded bg-white/80 space-y-4">
+          <div class="flex items-start justify-between">
+            <h3 class="text-lg font-semibold">Prévisualisation</h3>
+            <div class="text-sm text-gray-600">appliqués : {{ preview.appliedFeatures?.length ?? 0 }}</div>
+          </div>
 
-          <hr class="my-2" />
-          <h4 class="font-medium">Compétences / Proficiencies</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="p in preview.previewCharacter?.proficiencies ?? []" :key="p">{{ p }}</li>
-            <li v-if="!(preview.previewCharacter?.proficiencies ?? []).length" class="text-gray-500">Aucune</li>
-          </ul>
-
-          <hr class="my-2" />
-          <h4 class="font-medium">Senses</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="s in preview.previewCharacter?.senses ?? []" :key="JSON.stringify(s)">{{ s.sense_type ? (s.sense_type + ' ' + (s.range??'') + (s.units?(' '+s.units):'')) : JSON.stringify(s) }}</li>
-            <li v-if="!(preview.previewCharacter?.senses ?? []).length" class="text-gray-500">Aucune</li>
-          </ul>
-        </div>
-
-        <!-- Right: spells / equipment / features -->
-        <div class="border rounded p-3 bg-white">
-          <h4 class="font-medium mb-2">Magie</h4>
-          <div v-if="preview.previewCharacter?.spellcasting">
-            <div class="text-sm">Ability: {{ preview.previewCharacter.spellcasting.ability ?? preview.previewCharacter.spellcasting?.meta?.ability ?? '—' }}</div>
-            <div class="text-sm">Spell save DC: {{ preview.previewCharacter.spellcasting?.meta?.spell_save_dc ?? preview.previewCharacter.spellcasting?.meta?.spell_save_dc ?? '—' }}</div>
-            <div class="text-sm">Spell attack mod: {{ preview.previewCharacter.spellcasting?.meta?.spell_attack_mod ?? '—' }}</div>
-            <div class="mt-2">
-              <div class="font-medium">Slots</div>
-              <div v-if="preview.previewCharacter.spellcasting.slots && Object.keys(preview.previewCharacter.spellcasting.slots).length">
-                <div v-for="(num, lvl) in preview.previewCharacter.spellcasting.slots" :key="lvl" class="text-sm">{{ lvl }} : {{ num }}</div>
+          <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div class="flex flex-col gap-4 sm:flex-row">
+              <div class="sm:w-40">
+                <div class="aspect-[4/5] w-full overflow-hidden rounded-lg bg-slate-200">
+                  <img
+                    :src="previewPortrait"
+                    :alt="`Portrait ${displayCharacterName}`"
+                    class="h-full w-full object-cover"
+                  />
+                </div>
               </div>
-              <div v-else class="text-sm text-gray-500">Aucun</div>
+              <div class="flex-1 space-y-4">
+                <div>
+                  <div class="text-xs uppercase tracking-wide text-gray-500">Nom du personnage</div>
+                  <div class="text-xl font-semibold text-slate-900">{{ displayCharacterName }}</div>
+                </div>
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <article
+                    v-for="summary in identitySummary"
+                    :key="summary.id"
+                    class="rounded-lg border border-slate-200 bg-white p-3 shadow-sm"
+                  >
+                    <div class="mb-2 h-20 overflow-hidden rounded-md bg-slate-200">
+                      <img
+                        :src="summary.image"
+                        :alt="`Illustration ${summary.name}`"
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    </div>
+                    <div class="space-y-2">
+                      <div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500">{{ summary.title }}</div>
+                        <div class="text-sm font-medium text-slate-900">{{ summary.name }}</div>
+                      </div>
+                      <p class="text-xs leading-snug text-gray-600 min-h-[3rem]">{{ summary.description }}</p>
+                    </div>
+                  </article>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <!-- Left: stats & proficiencies -->
+            <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h4 class="font-medium mb-2">Caractéristiques</h4>
+              <table class="w-full text-sm">
+                <tr v-for="(val, key) in displayStats" :key="key">
+                  <td class="pr-3 font-medium">{{ key }}</td>
+                  <td>{{ val }}</td>
+                </tr>
+              </table>
+
+              <hr class="my-2" />
+              <h4 class="font-medium">Compétences / Proficiencies</h4>
+              <ul class="list-disc ml-5 text-sm">
+                <li v-for="p in preview.previewCharacter?.proficiencies ?? []" :key="p">{{ p }}</li>
+                <li v-if="!(preview.previewCharacter?.proficiencies ?? []).length" class="text-gray-500">Aucune</li>
+              </ul>
+
+              <hr class="my-2" />
+              <h4 class="font-medium">Senses</h4>
+              <ul class="list-disc ml-5 text-sm">
+                <li v-for="s in preview.previewCharacter?.senses ?? []" :key="JSON.stringify(s)">{{ s.sense_type ? (s.sense_type + ' ' + (s.range??'') + (s.units?(' '+s.units):'')) : JSON.stringify(s) }}</li>
+                <li v-if="!(preview.previewCharacter?.senses ?? []).length" class="text-gray-500">Aucune</li>
+              </ul>
             </div>
 
-            <div class="mt-2">
-              <div class="font-medium">Sorts connus</div>
+            <!-- Right: spells / equipment / features -->
+            <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h4 class="font-medium mb-2">Magie</h4>
+              <div v-if="preview.previewCharacter?.spellcasting">
+                <div class="text-sm">Ability: {{ preview.previewCharacter.spellcasting.ability ?? preview.previewCharacter.spellcasting?.meta?.ability ?? '—' }}</div>
+                <div class="text-sm">Spell save DC: {{ preview.previewCharacter.spellcasting?.meta?.spell_save_dc ?? preview.previewCharacter.spellcasting?.meta?.spell_save_dc ?? '—' }}</div>
+                <div class="text-sm">Spell attack mod: {{ preview.previewCharacter.spellcasting?.meta?.spell_attack_mod ?? '—' }}</div>
+                <div class="mt-2">
+                  <div class="font-medium">Slots</div>
+                  <div v-if="preview.previewCharacter.spellcasting.slots && Object.keys(preview.previewCharacter.spellcasting.slots).length">
+                    <div v-for="(num, lvl) in preview.previewCharacter.spellcasting.slots" :key="lvl" class="text-sm">{{ lvl }} : {{ num }}</div>
+                  </div>
+                  <div v-else class="text-sm text-gray-500">Aucun</div>
+                </div>
+
+                <div class="mt-2">
+                  <div class="font-medium">Sorts connus</div>
+                  <ul class="list-disc ml-5 text-sm">
+                    <li v-for="s in preview.previewCharacter.spellcasting.known ?? []" :key="s">{{ s }}</li>
+                    <li v-if="!(preview.previewCharacter.spellcasting.known ?? []).length" class="text-gray-500">Aucun</li>
+                  </ul>
+                </div>
+              </div>
+              <div v-else class="text-sm text-gray-500">Aucune capacité de lanceur de sorts détectée</div>
+
+              <hr class="my-2" />
+              <h4 class="font-medium">Équipement</h4>
               <ul class="list-disc ml-5 text-sm">
-                <li v-for="s in preview.previewCharacter.spellcasting.known ?? []" :key="s">{{ s }}</li>
-                <li v-if="!(preview.previewCharacter.spellcasting.known ?? []).length" class="text-gray-500">Aucun</li>
+                <li v-for="e in preview.previewCharacter?.equipment ?? []" :key="JSON.stringify(e)">{{ e }}</li>
+                <li v-if="!(preview.previewCharacter?.equipment ?? []).length" class="text-gray-500">Aucun</li>
+              </ul>
+
+              <hr class="my-2" />
+              <h4 class="font-medium">Features appliqués</h4>
+              <ul class="list-disc ml-5 text-sm">
+                <li v-for="f in preview.appliedFeatures ?? []" :key="f">{{ f }}</li>
+                <li v-if="!(preview.appliedFeatures ?? []).length" class="text-gray-500">Aucun</li>
               </ul>
             </div>
           </div>
-          <div v-else class="text-sm text-gray-500">Aucune capacité de lanceur de sorts détectée</div>
 
-          <hr class="my-2" />
-          <h4 class="font-medium">Équipement</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="e in preview.previewCharacter?.equipment ?? []" :key="JSON.stringify(e)">{{ e }}</li>
-            <li v-if="!(preview.previewCharacter?.equipment ?? []).length" class="text-gray-500">Aucun</li>
-          </ul>
-
-          <hr class="my-2" />
-          <h4 class="font-medium">Features appliqués</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="f in preview.appliedFeatures ?? []" :key="f">{{ f }}</li>
-            <li v-if="!(preview.appliedFeatures ?? []).length" class="text-gray-500">Aucun</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- Errors / unhandled effects -->
-      <div v-if="preview.errors && preview.errors.length" class="mt-4 p-3 border rounded bg-red-50 text-sm text-red-700">
-        <div class="font-medium">Erreurs détectées</div>
-        <ul class="list-disc ml-5">
-          <li v-for="(e, i) in preview.errors" :key="i">{{ e.type }} — {{ e.message }}</li>
-        </ul>
-      </div>
-    </section>
-
-    <!-- Raw response debug -->
-    <div class="mb-6">
-      <button @click="showRaw = !showRaw" class="px-3 py-1 rounded border">
-        {{ showRaw ? 'Cacher Raw response (debug)' : 'Voir Raw response (debug)' }}
-      </button>
-      <div v-if="showRaw" class="mt-3">
-        <pre class="whitespace-pre-wrap bg-slate-100 p-3 rounded text-sm overflow-auto" style="max-height:400px">{{ rawText }}</pre>
+          <!-- Errors / unhandled effects -->
+          <div v-if="preview.errors && preview.errors.length" class="p-3 border rounded bg-red-50 text-sm text-red-700">
+            <div class="font-medium">Erreurs détectées</div>
+            <ul class="list-disc ml-5">
+              <li v-for="(e, i) in preview.errors" :key="i">{{ e.type }} — {{ e.message }}</li>
+            </ul>
+          </div>
+        </section>
+        <section v-else class="p-4 border rounded bg-white/60 text-sm text-gray-600">
+          Lancez une prévisualisation pour voir un aperçu détaillé du personnage.
+        </section>
       </div>
     </div>
   </div>
@@ -313,6 +382,14 @@ type ChoiceOption = {
   image?: string | null;
 };
 
+type IdentitySummaryEntry = {
+  id: PrimarySelectionGroup['id'];
+  title: string;
+  name: string;
+  description: string;
+  image: string;
+};
+
 const classes = ref<CatalogEntry[]>([]);
 const races = ref<CatalogEntry[]>([]);
 const backgrounds = ref<CatalogEntry[]>([]);
@@ -322,6 +399,7 @@ const selectedRace = ref<string>('');
 const selectedBackground = ref<string>('');
 const niveau = ref<number>(1);
 const loading = ref(false);
+const characterName = ref<string>('');
 
 const TEXT_FIELDS = ['description', 'desc', 'summary', 'flavor', 'flavor_text', 'text'];
 const IMAGE_FIELDS = ['image', 'img', 'icon', 'art', 'avatar', 'illustration', 'picture', 'thumbnail'];
@@ -481,6 +559,34 @@ const primarySelectionGroups = computed<PrimarySelectionGroup[]>(() => [
     selected: selectedBackground.value
   }
 ]);
+
+const identitySummary = computed<IdentitySummaryEntry[]>(() =>
+  primarySelectionGroups.value.map((group) => {
+    const selected = group.options.find((option) => option.id === group.selected) ?? null;
+    const placeholderLabel = selected?.label ?? group.title;
+    return {
+      id: group.id,
+      title: group.title,
+      name: selected?.label ?? '—',
+      description: ensureDescription(selected?.description ?? null, placeholderLabel, group.title),
+      image: ensureCardImage(selected?.image ?? null, placeholderLabel)
+    };
+  })
+);
+
+const displayCharacterName = computed(() => {
+  const trimmed = characterName.value.trim();
+  if (trimmed.length) {
+    return trimmed;
+  }
+  const classEntry = identitySummary.value.find((entry) => entry.id === 'class');
+  if (classEntry && classEntry.name !== '—') {
+    return `${classEntry.name} sans nom`;
+  }
+  return 'Aventurier sans nom';
+});
+
+const previewPortrait = computed(() => createCardPlaceholder(displayCharacterName.value));
 
 const selectPrimaryOption = (
   groupId: PrimarySelectionGroup['id'],
@@ -906,6 +1012,7 @@ const sendPreview = async () => {
   preview.value = null;
   rawText.value = '';
   try {
+    const trimmedName = characterName.value.trim();
     const body = {
       selection: {
         class: selectedClass.value || null,
@@ -916,6 +1023,7 @@ const sendPreview = async () => {
         chosenOptions: { ...chosenOptions }
       },
       baseCharacter: {
+        name: trimmedName.length ? trimmedName : null,
         base_stats_before_race: { ...baseStats }
       }
     };
@@ -1002,6 +1110,7 @@ const resetChosenOptions = async () => {
   for (const k of Object.keys(choiceMetadata)) {
     delete choiceMetadata[k];
   }
+  characterName.value = '';
   // optional: refresh preview without choices
   await sendPreview();
 };


### PR DESCRIPTION
## Summary
- split the creation wizard into dedicated panels for selections and the final preview
- show catalog cards with explicit name/description labels and consistent placeholder imagery
- surface character identity details in the preview with editable name support and placeholder portrait

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3cd1083c0832ab47c4bf1dcf0c54d