### PR TITLE
feat: add book card component and enrich catalog metadata

### DIFF
--- a/components/BookCardTailwind.vue
+++ b/components/BookCardTailwind.vue
@@ -1,0 +1,86 @@
+<template>
+  <div
+    class="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition"
+  >
+    <div class="relative aspect-[4/3] w-full overflow-hidden bg-slate-200">
+      <img
+        v-if="hasImage"
+        :src="resolvedImage"
+        :alt="`Illustration ${name}`"
+        class="h-full w-full object-cover"
+        loading="lazy"
+      />
+      <div
+        v-else
+        class="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-200 to-slate-300 text-sm font-medium text-slate-600"
+      >
+        <span>{{ initials }}</span>
+      </div>
+    </div>
+    <div class="flex flex-1 flex-col gap-3 p-4">
+      <p class="text-base font-semibold leading-tight text-slate-900">
+        {{ name }}
+      </p>
+      <p class="flex-1 whitespace-pre-line text-sm leading-snug text-slate-600" v-if="descriptionContent">
+        {{ descriptionContent }}
+      </p>
+      <p v-else class="flex-1 text-sm italic leading-snug text-slate-500">
+        Aucune description disponible.
+      </p>
+      <div
+        v-if="effectLabelContent"
+        class="rounded-md bg-indigo-50 px-3 py-2 text-xs font-medium text-indigo-700"
+      >
+        {{ effectLabelContent }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    name: string;
+    description?: string | null;
+    effectLabel?: string | null;
+    effect_label?: string | null;
+    image?: string | null;
+  }>(),
+  {
+    description: null,
+    effectLabel: null,
+    effect_label: null,
+    image: null
+  }
+);
+
+const trimmed = (value: string | null | undefined): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const result = value.trim();
+  return result.length ? result : null;
+};
+
+const resolvedEffectLabel = computed(() => trimmed(props.effectLabel) ?? trimmed(props.effect_label));
+const descriptionContent = computed(() => trimmed(props.description));
+const effectLabelContent = computed(() => resolvedEffectLabel.value ?? null);
+
+const resolvedImage = computed(() => trimmed(props.image));
+const hasImage = computed(() => Boolean(resolvedImage.value));
+
+const initials = computed(() => {
+  const parts = props.name
+    .split(/\s+/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+    .slice(0, 2);
+  if (!parts.length) {
+    return '—';
+  }
+  const candidate = parts.map((segment) => segment[0]!.toUpperCase()).join('');
+  return candidate || '—';
+});
+</script>

--- a/tests/catalogHandlers.test.ts
+++ b/tests/catalogHandlers.test.ts
@@ -11,6 +11,26 @@ class SuccessAdapter {
         'rogue'
       ];
     }
+    if (repoPath === 'classes/wizard.json') {
+      return {
+        id: 'wizard',
+        name: 'Wizard',
+        description: 'Maître des arcanes',
+        image: 'https://cdn.test/wizard.png',
+        effect_label: 'Réaction : +5 CA jusqu\'au prochain tour.'
+      };
+    }
+    if (repoPath === 'classes/fighter.json') {
+      return {
+        id: 'fighter',
+        name: 'Fighter',
+        description: 'Guerrier polyvalent',
+        effectLabel: 'Action bonus : Second souffle'
+      };
+    }
+    if (repoPath === 'classes/rogue.json') {
+      return { id: 'rogue', name: 'Rogue' };
+    }
     if (repoPath === 'races/index.json') {
       return [
         { id: 'humain', name: 'Humain', description: 'Polyvalent' },
@@ -18,11 +38,32 @@ class SuccessAdapter {
         'nain'
       ];
     }
+    if (repoPath === 'races/humain.json') {
+      return { id: 'humain', name: 'Humain', description: 'Polyvalent', effect_label: 'Polyvalence humaine' };
+    }
+    if (repoPath === 'races/elfe.json') {
+      return { id: 'elfe', name: 'Elfe', image: 'https://cdn.test/elfe.png' };
+    }
+    if (repoPath === 'races/nain.json') {
+      return { id: 'nain', name: 'Nain' };
+    }
     if (repoPath === 'backgrounds/index.json') {
       return [
         { key: 'acolyte', description: 'Serviteur du temple', image: 'https://cdn.test/acolyte.png' },
         { id: 'artisan', label: 'Artisan' }
       ];
+    }
+    if (repoPath === 'backgrounds/acolyte.json') {
+      return {
+        id: 'acolyte',
+        name: 'Acolyte',
+        description: 'Serviteur du temple',
+        image: 'https://cdn.test/acolyte.png',
+        effect_label: 'Compétences : Religion, Persuasion'
+      };
+    }
+    if (repoPath === 'backgrounds/artisan.json') {
+      return { id: 'artisan', name: 'Artisan' };
     }
     throw new Error(`unexpected path: ${repoPath}`);
   }
@@ -97,19 +138,25 @@ export async function run() {
       id: 'wizard',
       name: 'Wizard',
       description: 'Maître des arcanes',
-      image: 'https://cdn.test/wizard.png'
+      image: 'https://cdn.test/wizard.png',
+      effectLabel: "Réaction : +5 CA jusqu'au prochain tour.",
+      effect_label: "Réaction : +5 CA jusqu'au prochain tour."
     },
     {
       id: 'fighter',
       name: 'Fighter',
       description: 'Guerrier polyvalent',
-      image: null
+      image: null,
+      effectLabel: 'Action bonus : Second souffle',
+      effect_label: 'Action bonus : Second souffle'
     },
     {
       id: 'rogue',
       name: 'Rogue',
       description: null,
-      image: null
+      image: null,
+      effectLabel: null,
+      effect_label: null
     }
   ]);
 
@@ -118,19 +165,25 @@ export async function run() {
       id: 'humain',
       name: 'Humain',
       description: 'Polyvalent',
-      image: null
+      image: null,
+      effectLabel: 'Polyvalence humaine',
+      effect_label: 'Polyvalence humaine'
     },
     {
       id: 'elfe',
       name: 'Elfe',
       description: null,
-      image: 'https://cdn.test/elfe.png'
+      image: 'https://cdn.test/elfe.png',
+      effectLabel: null,
+      effect_label: null
     },
     {
       id: 'nain',
       name: 'Nain',
       description: null,
-      image: null
+      image: null,
+      effectLabel: null,
+      effect_label: null
     }
   ]);
 
@@ -139,13 +192,17 @@ export async function run() {
       id: 'acolyte',
       name: 'Acolyte',
       description: 'Serviteur du temple',
-      image: 'https://cdn.test/acolyte.png'
+      image: 'https://cdn.test/acolyte.png',
+      effectLabel: 'Compétences : Religion, Persuasion',
+      effect_label: 'Compétences : Religion, Persuasion'
     },
     {
       id: 'artisan',
       name: 'Artisan',
       description: null,
-      image: null
+      image: null,
+      effectLabel: null,
+      effect_label: null
     }
   ]);
 
@@ -155,17 +212,17 @@ export async function run() {
   const backgroundsFallback = await backgroundsHandler({} as any);
 
   assert.deepEqual(classesFallback, [
-    { id: 'barbare', name: 'Barbare', description: null, image: null },
-    { id: 'barde', name: 'Barde', description: null, image: null },
-    { id: 'ensorceleur', name: 'Ensorceleur', description: null, image: null }
+    { id: 'barbare', name: 'Barbare', description: null, image: null, effectLabel: null, effect_label: null },
+    { id: 'barde', name: 'Barde', description: null, image: null, effectLabel: null, effect_label: null },
+    { id: 'ensorceleur', name: 'Ensorceleur', description: null, image: null, effectLabel: null, effect_label: null }
   ]);
   assert.deepEqual(racesFallback, [
-    { id: 'elfe', name: 'Elfe', description: null, image: null },
-    { id: 'nain', name: 'Nain', description: null, image: null }
+    { id: 'elfe', name: 'Elfe', description: null, image: null, effectLabel: null, effect_label: null },
+    { id: 'nain', name: 'Nain', description: null, image: null, effectLabel: null, effect_label: null }
   ]);
   assert.deepEqual(backgroundsFallback, [
-    { id: 'acolyte', name: 'Acolyte', description: null, image: null },
-    { id: 'soldat', name: 'Soldat', description: null, image: null }
+    { id: 'acolyte', name: 'Acolyte', description: null, image: null, effectLabel: null, effect_label: null },
+    { id: 'soldat', name: 'Soldat', description: null, image: null, effectLabel: null, effect_label: null }
   ]);
 
   const originalError = console.error;

--- a/tests/creationAdapter.test.ts
+++ b/tests/creationAdapter.test.ts
@@ -109,7 +109,16 @@ export async function run() {
   );
   assert.deepEqual(
     spellChoice.from_labels,
-    [{ id: 'spell_magic_missile', label: 'Projectiles magiques' }],
+    [
+      {
+        id: 'spell_magic_missile',
+        label: 'Projectiles magiques',
+        description: null,
+        effectLabel: null,
+        effect_label: null,
+        image: null
+      }
+    ],
     'auto_from should provide labels for filtered spells'
   );
 


### PR DESCRIPTION
## Summary
- create a reusable `BookCardTailwind` component to render selection cards with image, description, and effect label
- update the wizard flow to display classes, races, backgrounds, and pending choices with the new card component
- enrich GitHub catalog and auto-from loaders to pull description/effect metadata and adjust associated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e814d490832abf0909baa4b42b84