### PR TITLE
Remove inline preview from BonomeWizard

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -69,9 +69,6 @@
       </div>
 
       <div class="mt-4 flex gap-2">
-        <button @click="sendPreview" :disabled="loading" class="px-3 py-2 rounded bg-blue-600 text-white">
-          {{ loading ? 'Prévisualisation...' : 'Prévisualiser' }}
-        </button>
         <button @click="resetChosenOptions" class="px-3 py-2 rounded border">Réinitialiser choix</button>
       </div>
     </section>
@@ -176,98 +173,6 @@
       </ul>
     </section>
 
-    <!-- Preview area -->
-    <section v-if="preview" class="mb-6 p-4 border rounded bg-white/80">
-      <div class="flex items-start justify-between">
-        <h3 class="text-lg font-semibold">Preview</h3>
-        <div class="text-sm text-gray-600">applied: {{ preview.appliedFeatures?.length ?? 0 }}</div>
-      </div>
-
-      <div class="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
-        <!-- Left: stats & proficiencies -->
-        <div class="border rounded p-3 bg-white">
-          <h4 class="font-medium mb-2">Caractéristiques</h4>
-          <table class="w-full text-sm">
-            <tr v-for="(val, key) in displayStats" :key="key">
-              <td class="pr-3 font-medium">{{ key }}</td>
-              <td>{{ val }}</td>
-            </tr>
-          </table>
-
-          <hr class="my-2" />
-          <h4 class="font-medium">Compétences / Proficiencies</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="p in preview.previewCharacter?.proficiencies ?? []" :key="p">{{ p }}</li>
-            <li v-if="!(preview.previewCharacter?.proficiencies ?? []).length" class="text-gray-500">Aucune</li>
-          </ul>
-
-          <hr class="my-2" />
-          <h4 class="font-medium">Senses</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="s in preview.previewCharacter?.senses ?? []" :key="JSON.stringify(s)">{{ s.sense_type ? (s.sense_type + ' ' + (s.range??'') + (s.units?(' '+s.units):'')) : JSON.stringify(s) }}</li>
-            <li v-if="!(preview.previewCharacter?.senses ?? []).length" class="text-gray-500">Aucune</li>
-          </ul>
-        </div>
-
-        <!-- Right: spells / equipment / features -->
-        <div class="border rounded p-3 bg-white">
-          <h4 class="font-medium mb-2">Magie</h4>
-          <div v-if="preview.previewCharacter?.spellcasting">
-            <div class="text-sm">Ability: {{ preview.previewCharacter.spellcasting.ability ?? preview.previewCharacter.spellcasting?.meta?.ability ?? '—' }}</div>
-            <div class="text-sm">Spell save DC: {{ preview.previewCharacter.spellcasting?.meta?.spell_save_dc ?? preview.previewCharacter.spellcasting?.meta?.spell_save_dc ?? '—' }}</div>
-            <div class="text-sm">Spell attack mod: {{ preview.previewCharacter.spellcasting?.meta?.spell_attack_mod ?? '—' }}</div>
-            <div class="mt-2">
-              <div class="font-medium">Slots</div>
-              <div v-if="preview.previewCharacter.spellcasting.slots && Object.keys(preview.previewCharacter.spellcasting.slots).length">
-                <div v-for="(num, lvl) in preview.previewCharacter.spellcasting.slots" :key="lvl" class="text-sm">{{ lvl }} : {{ num }}</div>
-              </div>
-              <div v-else class="text-sm text-gray-500">Aucun</div>
-            </div>
-
-            <div class="mt-2">
-              <div class="font-medium">Sorts connus</div>
-              <ul class="list-disc ml-5 text-sm">
-                <li v-for="s in preview.previewCharacter.spellcasting.known ?? []" :key="s">{{ s }}</li>
-                <li v-if="!(preview.previewCharacter.spellcasting.known ?? []).length" class="text-gray-500">Aucun</li>
-              </ul>
-            </div>
-          </div>
-          <div v-else class="text-sm text-gray-500">Aucune capacité de lanceur de sorts détectée</div>
-
-          <hr class="my-2" />
-          <h4 class="font-medium">Équipement</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="e in preview.previewCharacter?.equipment ?? []" :key="JSON.stringify(e)">{{ e }}</li>
-            <li v-if="!(preview.previewCharacter?.equipment ?? []).length" class="text-gray-500">Aucun</li>
-          </ul>
-
-          <hr class="my-2" />
-          <h4 class="font-medium">Features appliqués</h4>
-          <ul class="list-disc ml-5 text-sm">
-            <li v-for="f in preview.appliedFeatures ?? []" :key="f">{{ f }}</li>
-            <li v-if="!(preview.appliedFeatures ?? []).length" class="text-gray-500">Aucun</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- Errors / unhandled effects -->
-      <div v-if="preview.errors && preview.errors.length" class="mt-4 p-3 border rounded bg-red-50 text-sm text-red-700">
-        <div class="font-medium">Erreurs détectées</div>
-        <ul class="list-disc ml-5">
-          <li v-for="(e, i) in preview.errors" :key="i">{{ e.type }} — {{ e.message }}</li>
-        </ul>
-      </div>
-    </section>
-
-    <!-- Raw response debug -->
-    <div class="mb-6">
-      <button @click="showRaw = !showRaw" class="px-3 py-1 rounded border">
-        {{ showRaw ? 'Cacher Raw response (debug)' : 'Voir Raw response (debug)' }}
-      </button>
-      <div v-if="showRaw" class="mt-3">
-        <pre class="whitespace-pre-wrap bg-slate-100 p-3 rounded text-sm overflow-auto" style="max-height:400px">{{ rawText }}</pre>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -285,11 +190,7 @@ const {
   niveau,
   baseStats,
   preview,
-  rawText,
-  showRaw,
-  loading,
-  appliedChoices,
-  displayStats
+  appliedChoices
 } = storeToRefs(creation);
 
 const {
@@ -311,16 +212,10 @@ const {
   resetChoice,
   hasLocalChoiceValue,
   resetChosenOptions,
-  resetChoiceById,
-  sendPreview
+  resetChoiceById
 } = creation;
 
 onMounted(() => {
   creation.initialize();
 });
 </script>
-
-
-<style scoped>
-/* minimal */
-</style>


### PR DESCRIPTION
## Summary
- remove the inline preview, debug toggle, and preview trigger from BonomeWizard
- clean up unused refs and methods that were only needed for the inline preview
- keep the wizard focused on selections, pending choices, and applied choices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66ac9a0f4832a8039bc307a855adf