### PR TITLE
Add saving flow for Bonome preview panel

### DIFF
--- a/components/BonomePreviewPanel.vue
+++ b/components/BonomePreviewPanel.vue
@@ -129,15 +129,66 @@
     </div>
 
     <div v-else class="text-sm text-gray-600">Lancez une prévisualisation pour voir un aperçu détaillé du personnage.</div>
+
+    <div class="pt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <p v-if="saveError" class="text-sm text-red-600">{{ saveError }}</p>
+      <button
+        class="btn self-end sm:self-auto"
+        type="button"
+        @click="handleSave"
+        :disabled="saving || !canSave"
+      >
+        <span v-if="saving">Sauvegarde…</span>
+        <span v-else>Sauvegarder ce personnage</span>
+      </button>
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
+import { useRouter } from '#app';
 import { useBonomeCreationStore } from '@/stores/bonomeCreation';
+import { usePersonnage } from '@/stores/personnage';
 
+const router = useRouter();
 const creation = useBonomeCreationStore();
+const personnageStore = usePersonnage();
+
 const { preview, identitySummary, displayCharacterName, previewPortrait, displayStats } = storeToRefs(creation);
+
+const canSave = computed(() => preview.value?.ok && !(preview.value?.errors?.length));
+const saving = ref(false);
+const saveError = ref<string | null>(null);
+
+async function handleSave() {
+  if (!canSave.value || saving.value) {
+    return;
+  }
+
+  saving.value = true;
+  saveError.value = null;
+
+  try {
+    const payload = await creation.createPersonnagePayload();
+    if (!payload) {
+      throw new Error("La génération du personnage n'a retourné aucune donnée.");
+    }
+
+    personnageStore.perso = payload;
+    personnageStore.sauvegarderLocal();
+
+    await router.push('/aventure');
+  } catch (err: any) {
+    // eslint-disable-next-line no-console
+    console.error('[BonomePreviewPanel] handleSave failed', err);
+    const message = err?.message ?? err;
+    saveError.value = message ? `Impossible de sauvegarder la fiche : ${String(message)}` : 'Impossible de sauvegarder la fiche.';
+  } finally {
+    saving.value = false;
+  }
+}
 </script>
 
 <style scoped>

--- a/stores/bonomeCreation.ts
+++ b/stores/bonomeCreation.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, ref } from 'vue';
+import type { Personnage } from './personnage';
 
 export type CatalogEntry = {
   id: string;
@@ -840,6 +841,133 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     return out;
   });
 
+  const createPersonnagePayload = async (): Promise<Personnage> => {
+    if (!preview.value?.ok) {
+      throw new Error('Aucune prévisualisation valide disponible.');
+    }
+
+    const previewCharacter = (preview.value?.previewCharacter ?? {}) as Record<string, any>;
+
+    const statsSource = {
+      ...(previewCharacter.base_stats_before_race ?? {}),
+      ...(previewCharacter.final_stats ?? {})
+    } as Record<string, unknown>;
+
+    const ensureNumber = (value: unknown, fallback = 0): number => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+      }
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+
+    const getStat = (key: keyof typeof baseStats) => {
+      if (key in statsSource) {
+        const candidate = statsSource[key];
+        if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+          return candidate;
+        }
+      }
+      const fallback = baseStats[key];
+      return typeof fallback === 'number' && Number.isFinite(fallback) ? fallback : 0;
+    };
+
+    const statMap: Array<{ target: keyof Personnage['caracs']; source: keyof typeof baseStats }> = [
+      { target: 'force', source: 'strength' },
+      { target: 'dexterite', source: 'dexterity' },
+      { target: 'constitution', source: 'constitution' },
+      { target: 'intelligence', source: 'intelligence' },
+      { target: 'sagesse', source: 'wisdom' },
+      { target: 'charisme', source: 'charisma' }
+    ];
+
+    const caracs = statMap.reduce((acc, entry) => {
+      acc[entry.target] = getStat(entry.source);
+      return acc;
+    }, {} as Personnage['caracs']);
+
+    const identityLabels = identitySummary.value.reduce<Record<string, string>>((acc, entry) => {
+      acc[entry.id] = entry.name;
+      return acc;
+    }, {});
+
+    const toDisplayString = (value: unknown, fallback = ''): string => {
+      if (typeof value === 'string' && value.trim().length) {
+        return value.trim();
+      }
+      return fallback;
+    };
+
+    const toList = (value: unknown): string[] => {
+      if (!Array.isArray(value)) {
+        return [];
+      }
+      return value
+        .map((entry) => {
+          if (typeof entry === 'string') {
+            return entry;
+          }
+          if (entry && typeof entry === 'object') {
+            if ('label' in entry && typeof entry.label === 'string') {
+              return entry.label;
+            }
+            if ('name' in entry && typeof entry.name === 'string') {
+              return entry.name;
+            }
+          }
+          try {
+            return JSON.stringify(entry);
+          } catch (err) {
+            return String(entry);
+          }
+        })
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+    };
+
+    const proficiencies = toList(previewCharacter.proficiencies).reduce<Record<string, boolean>>((acc, entry) => {
+      acc[entry] = true;
+      return acc;
+    }, {});
+
+    const languages = toList(previewCharacter.languages);
+    const equipment = toList(previewCharacter.equipment);
+
+    const personnage: Personnage = {
+      id: toDisplayString(previewCharacter.id, `pj_${Date.now()}`),
+      nom: displayCharacterName.value,
+      lignee: toDisplayString(identityLabels.race, '—'),
+      age: ensureNumber(previewCharacter.age, 18),
+      alignement: toDisplayString(previewCharacter.alignement, 'Neutre'),
+      historique: toDisplayString(identityLabels.background, ''),
+      classe: toDisplayString(identityLabels.class, ''),
+      sousClasse: toDisplayString(previewCharacter.subclass ?? previewCharacter.sousClasse, ''),
+      niveau: ensureNumber(previewCharacter.niveau ?? niveau.value, 1),
+      dv: ensureNumber(previewCharacter.dv ?? previewCharacter.hit_dice, 0),
+      pvActuels: ensureNumber(
+        previewCharacter.pvActuels ??
+          previewCharacter.hp?.current ??
+          previewCharacter.final_stats?.hp ??
+          previewCharacter.hp,
+        0
+      ),
+      caracs,
+      competences: proficiencies,
+      langues: languages.length ? languages.join(', ') : 'Commun',
+      equipement: equipment.join(', '),
+      armure: { type: 'aucune' },
+      bouclier: Boolean(previewCharacter.bouclier ?? false),
+      monture: {
+        nom: toDisplayString(previewCharacter.monture?.nom ?? ''),
+        vitesse: toDisplayString(previewCharacter.monture?.vitesse ?? ''),
+        notes: toDisplayString(previewCharacter.monture?.notes ?? '')
+      },
+      inspiration: Boolean(previewCharacter.inspiration ?? false)
+    };
+
+    return personnage;
+  };
+
   const initialize = async () => {
     restoreSelections();
     if (initialized.value) return;
@@ -893,6 +1021,7 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     appliedChoices,
     sendPreview,
     loadCatalog,
-    initialize
+    initialize,
+    createPersonnagePayload
   };
 });


### PR DESCRIPTION
## Summary
- add a save action to the Bonome preview panel so players can persist and redirect to the adventure
- expose a `createPersonnagePayload` helper on the creation store to translate the preview into the personnage format

## Testing
- npm test *(fails: ReferenceError: useRequestFetch is not defined in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68da31da7dc0832ab0134cc2e6717cb8