### PR TITLE
Use CardArticleSpells in Bonome wizard selections

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -19,7 +19,7 @@
 
           <div v-if="group.options.length" class="-mx-1 px-1">
             <div
-              class="grid grid-flow-col auto-cols-[minmax(18rem,1fr)] lg:auto-cols-[18rem] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+              class="grid grid-flow-col auto-cols-[360px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
             >
               <button
                 v-for="option in group.options"
@@ -29,13 +29,13 @@
                 :aria-pressed="group.selected === option.id"
                 @click="selectPrimaryOption(group.id, option.id)"
               >
-                <BookCardTailwind
-                  :name="option.label"
+                <CardArticleSpells
+                  :title="option.label"
                   :description="option.description"
-                  :effect-label="option.effectLabel ?? null"
+                  :effact-label="option.effectLabel ?? undefined"
                   :image="option.image"
+                  :show-actions="false"
                   :class="[
-                    'h-full',
                     group.selected === option.id
                       ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
                       : 'hover:border-slate-300 hover:shadow'
@@ -98,7 +98,7 @@
 
             <div class="-mx-1 px-1">
               <div
-                class="grid grid-flow-col auto-cols-[minmax(18rem,1fr)] lg:auto-cols-[18rem] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+                class="grid grid-flow-col auto-cols-[360px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
               >
                 <button
                   v-for="(opt, optIdx) in getChoiceOptions(choice)"
@@ -111,13 +111,13 @@
                   :disabled="isChoiceOptionDisabled(choice, opt)"
                   @click="handleChoiceOptionClick(choice, opt)"
                 >
-                  <BookCardTailwind
-                    :name="opt.label"
+                  <CardArticleSpells
+                    :title="opt.label"
                     :description="getChoiceOptionDescription(opt)"
-                    :effect-label="opt.effectLabel ?? opt.effect_label ?? null"
+                    :effact-label="opt.effectLabel ?? opt.effect_label ?? undefined"
                     :image="getChoiceOptionImage(opt)"
+                    :show-actions="false"
                     :class="[
-                      'h-full',
                       isChoiceOptionSelected(choice, opt)
                         ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
                         : 'hover:border-slate-300 hover:shadow'
@@ -180,7 +180,7 @@
 import { onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import BookCardTailwind from '~/components/BookCardTailwind.vue';
+import CardArticleSpells from '~/components/CardArticleSpells.vue';
 import { useBonomeCreationStore } from '~/stores/bonomeCreation';
 
 const creation = useBonomeCreationStore();

--- a/components/CardArticleSpells.vue
+++ b/components/CardArticleSpells.vue
@@ -24,7 +24,10 @@
     </div>
 
     <!-- Footer (badge + fixed-size button) -->
-    <footer class="px-6 py-4 border-t border-slate-800 relative bg-gradient-to-t from-transparent to-transparent">
+    <footer
+      v-if="props.showActions"
+      class="px-6 py-4 border-t border-slate-800 relative bg-gradient-to-t from-transparent to-transparent"
+    >
       <div class="flex items-center justify-between gap-4">
         <div class="text-sm text-slate-400">
           <slot name="meta"></slot>
@@ -114,11 +117,13 @@ const props = withDefaults(defineProps<{
   href?: string
   effactLabel?: string
   effactVariant?: 'primary' | 'light' | 'outline'
+  showActions?: boolean
 }>(), {
   description: '',
   imageAlt: 'Card image',
   href: '#',
-  effactVariant: 'primary'
+  effactVariant: 'primary',
+  showActions: true
 })
 
 /* state */


### PR DESCRIPTION
## Summary
- add a showActions flag to CardArticleSpells to optionally hide the footer actions
- use CardArticleSpells in the Bonome wizard carousels with consistent card sizing
- update carousel column sizing to match the fixed card width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da62a459e8832a9d9774be019f23d2