### PR TITLE
Add Tailwind line clamp plugin

### DIFF
--- a/components/BonomePreviewPanel.vue
+++ b/components/BonomePreviewPanel.vue
@@ -36,7 +36,7 @@
                   <div class="text-xs uppercase tracking-wide text-gray-500">{{ summary.title }}</div>
                   <div class="text-sm font-medium text-slate-900">{{ summary.name }}</div>
                 </div>
-                <p class="text-xs leading-snug text-gray-600 min-h-[3rem]">{{ summary.description }}</p>
+                <p class="text-xs leading-snug text-gray-600 line-clamp-6">{{ summary.description }}</p>
               </div>
             </article>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@nuxtjs/tailwindcss": "^6.14.0",
+        "@tailwindcss/line-clamp": "file:packages/tailwindcss-line-clamp",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.21",
@@ -3324,6 +3325,10 @@
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.7.tgz",
       "integrity": "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==",
       "license": "CC0-1.0"
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "resolved": "packages/tailwindcss-line-clamp",
+      "link": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -11628,6 +11633,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "packages/tailwindcss-line-clamp": {
+      "name": "@tailwindcss/line-clamp",
+      "version": "0.4.4",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@tailwindcss/line-clamp": "file:packages/tailwindcss-line-clamp",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/packages/tailwindcss-line-clamp/index.js
+++ b/packages/tailwindcss-line-clamp/index.js
@@ -1,0 +1,50 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(
+  function ({ matchUtilities, theme }) {
+    matchUtilities(
+      {
+        'line-clamp': (value) => {
+          if (value === 'none') {
+            return {
+              overflow: 'visible',
+              display: 'block',
+              '-webkit-box-orient': 'horizontal',
+              '-webkit-line-clamp': 'unset'
+            };
+          }
+
+          return {
+            overflow: 'hidden',
+            display: '-webkit-box',
+            '-webkit-box-orient': 'vertical',
+            '-webkit-line-clamp': String(value)
+          };
+        }
+      },
+      {
+        values: {
+          none: 'none',
+          ...theme('lineClamp')
+        },
+        supportsNegativeValues: false
+      }
+    );
+  },
+  {
+    theme: {
+      lineClamp: {
+        1: '1',
+        2: '2',
+        3: '3',
+        4: '4',
+        5: '5',
+        6: '6',
+        7: '7',
+        8: '8',
+        9: '9',
+        10: '10'
+      }
+    }
+  }
+);

--- a/packages/tailwindcss-line-clamp/package.json
+++ b/packages/tailwindcss-line-clamp/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@tailwindcss/line-clamp",
+  "version": "0.4.4",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import lineClamp from '@tailwindcss/line-clamp';
 
 export default {
   content: [
@@ -14,5 +15,5 @@ export default {
   theme: {
     extend: {}
   },
-  plugins: []
+  plugins: [lineClamp]
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add a vendored `@tailwindcss/line-clamp` package and register it with Tailwind so line clamp utilities are available
to the app
- clamp preview card descriptions to six lines to prevent tall cards with verbose content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7b3240c8832a8a20c2e3fe57aed5