### PR TITLE
Align spell card and button widths in carousel

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -25,7 +25,7 @@
                 v-for="option in group.options"
                 :key="option.id"
                 type="button"
-                class="snap-center w-full text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                class="snap-center w-[360px] min-w-[360px] max-w-[360px] shrink-0 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 :aria-pressed="group.selected === option.id"
                 @click="selectPrimaryOption(group.id, option.id)"
               >
@@ -104,7 +104,7 @@
                   v-for="(opt, optIdx) in getChoiceOptions(choice)"
                   :key="typeof opt.value === 'object' ? optIdx : (opt.value ?? optIdx)"
                   type="button"
-                  class="snap-center w-full text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  class="snap-center w-[360px] min-w-[360px] max-w-[360px] shrink-0 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   :class="{
                     'cursor-not-allowed opacity-60': isChoiceOptionDisabled(choice, opt)
                   }"

--- a/components/CardArticleSpells.vue
+++ b/components/CardArticleSpells.vue
@@ -183,7 +183,7 @@ const buttonLabel = computed(() => {
    - glow appliqué à la card (et n'affecte pas la taille du layout)
 */
 const cardClass = computed(() => {
-  const width = 'w-[360px]'      // fixe largeur
+  const width = 'w-[360px] min-w-[360px] max-w-[360px] shrink-0'      // fixe largeur
   const height = 'h-[460px]'     // fixe hauteur
   const surfaceColors = 'bg-[#0f1330] text-slate-100'
   const base = `relative ${width} ${height} rounded-2xl overflow-hidden ${surfaceColors} group flex flex-col transform-gpu transition-transform duration-300`


### PR DESCRIPTION
## Summary
- ensure CardArticleSpells keeps a fixed width by adding matching min/max constraints
- align BonomeWizard option button widths with the card dimensions to maintain consistent hit areas

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da82ef1dc8832a95272e3abfa0fc41