### PR TITLE
Ensure spell card descriptions wrap within cards

### DIFF
--- a/components/CardArticleSpells.vue
+++ b/components/CardArticleSpells.vue
@@ -18,7 +18,7 @@
           {{ props.title }}
       </h3>
 
-      <p class="mt-3 text-slate-200 line-clamp-6">
+      <p class="mt-3 text-slate-200 line-clamp-6 break-words whitespace-pre-line">
         {{ props.description }}
       </p>
     </div>


### PR DESCRIPTION
## Summary
- add word-breaking utilities to spell card descriptions so long text wraps within the card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8579e698832a97795de5a8445b09