### PR TITLE
Refine spell selection CTAs

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -21,27 +21,26 @@
             <div
               class="grid grid-flow-col auto-cols-[360px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
             >
-              <button
+              <CardArticleSpells
                 v-for="option in group.options"
                 :key="option.id"
-                type="button"
-                class="snap-center w-[360px] min-w-[360px] max-w-[360px] shrink-0 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                :aria-pressed="group.selected === option.id"
-                @click="selectPrimaryOption(group.id, option.id)"
-              >
-                <CardArticleSpells
-                  :title="option.label"
-                  :description="option.description"
-                  :effact-label="option.effectLabel ?? undefined"
-                  :image="option.image"
-                  :show-actions="false"
-                  :class="[
-                    group.selected === option.id
-                      ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
-                      : 'hover:border-slate-300 hover:shadow'
-                  ]"
-                />
-              </button>
+                :title="option.label"
+                :description="option.description"
+                :effact-label="option.effectLabel ?? undefined"
+                :image="option.image"
+                :show-actions="false"
+                role="option"
+                :aria-selected="group.selected === option.id"
+                :cta="group.selected === option.id ? 'Sélectionné' : 'Choisir'"
+                :cta-variant="group.selected === option.id ? 'secondary' : 'primary'"
+                :class="[
+                  'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+                  group.selected === option.id
+                    ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
+                    : 'hover:border-slate-300 hover:shadow'
+                ]"
+                @select="selectPrimaryOption(group.id, option.id)"
+              />
             </div>
           </div>
           <div v-else class="text-sm text-gray-500">Aucune option disponible pour l'instant.</div>
@@ -100,30 +99,28 @@
               <div
                 class="grid grid-flow-col auto-cols-[360px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
               >
-                <button
+                <CardArticleSpells
                   v-for="(opt, optIdx) in getChoiceOptions(choice)"
                   :key="typeof opt.value === 'object' ? optIdx : (opt.value ?? optIdx)"
-                  type="button"
-                  class="snap-center w-[360px] min-w-[360px] max-w-[360px] shrink-0 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                  :class="{
-                    'cursor-not-allowed opacity-60': isChoiceOptionDisabled(choice, opt)
-                  }"
-                  :disabled="isChoiceOptionDisabled(choice, opt)"
-                  @click="handleChoiceOptionClick(choice, opt)"
-                >
-                  <CardArticleSpells
-                    :title="opt.label"
-                    :description="getChoiceOptionDescription(opt)"
-                    :effact-label="opt.effectLabel ?? opt.effect_label ?? undefined"
-                    :image="getChoiceOptionImage(opt)"
-                    :show-actions="false"
-                    :class="[
-                      isChoiceOptionSelected(choice, opt)
-                        ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
-                        : 'hover:border-slate-300 hover:shadow'
-                    ]"
-                  />
-                </button>
+                  :title="opt.label"
+                  :description="getChoiceOptionDescription(opt)"
+                  :effact-label="opt.effectLabel ?? opt.effect_label ?? undefined"
+                  :image="getChoiceOptionImage(opt)"
+                  :show-actions="false"
+                  role="option"
+                  :aria-selected="isChoiceOptionSelected(choice, opt)"
+                  :cta="isChoiceOptionSelected(choice, opt) ? 'Sélectionné' : 'Choisir'"
+                  :cta-variant="isChoiceOptionSelected(choice, opt) ? 'secondary' : 'primary'"
+                  :cta-disabled="isChoiceOptionDisabled(choice, opt)"
+                  :class="[
+                    'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+                    isChoiceOptionSelected(choice, opt)
+                      ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
+                      : 'hover:border-slate-300 hover:shadow',
+                    isChoiceOptionDisabled(choice, opt) ? 'cursor-not-allowed opacity-60' : ''
+                  ]"
+                  @select="handleChoiceOptionClick(choice, opt)"
+                />
               </div>
             </div>
 

--- a/components/CardArticleSpells.vue
+++ b/components/CardArticleSpells.vue
@@ -25,7 +25,7 @@
 
     <!-- Footer (badge + fixed-size button) -->
     <footer
-      v-if="props.showActions"
+      v-if="props.showActions || hasCta"
       class="px-6 py-4 border-t border-slate-800 relative bg-gradient-to-t from-transparent to-transparent"
     >
       <div class="flex items-center justify-between gap-4">
@@ -49,7 +49,7 @@
           </div>
 
           <!-- Action button (FIXED size) -->
-          <div class="relative" ref="btnWrapper">
+          <div v-if="props.showActions" class="relative" ref="btnWrapper">
             <button
               @click="toggleMenu"
               :aria-expanded="isOpen"
@@ -96,6 +96,19 @@
               </ul>
             </div>
           </div>
+
+          <div v-else-if="hasCta">
+            <button
+              type="button"
+              class="w-36 h-10 inline-flex items-center justify-center rounded-xl px-4 py-2 font-medium text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 transition-colors truncate"
+              :class="ctaButtonClass"
+              :disabled="props.ctaDisabled"
+              :aria-label="props.cta"
+              @click="emit('select')"
+            >
+              <span class="truncate max-w-[10rem]">{{ props.cta }}</span>
+            </button>
+          </div>
         </div>
       </div>
     </footer>
@@ -106,7 +119,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 /* emits */
-const emit = defineEmits(['write', 'write-prepare', 'reset'])
+const emit = defineEmits(['write', 'write-prepare', 'reset', 'select'])
 
 /* props */
 const props = withDefaults(defineProps<{
@@ -118,12 +131,17 @@ const props = withDefaults(defineProps<{
   effactLabel?: string
   effactVariant?: 'primary' | 'light' | 'outline'
   showActions?: boolean
+  cta?: string
+  ctaVariant?: 'primary' | 'secondary'
+  ctaDisabled?: boolean
 }>(), {
   description: '',
   imageAlt: 'Card image',
   href: '#',
   effactVariant: 'primary',
-  showActions: true
+  showActions: true,
+  ctaVariant: 'primary',
+  ctaDisabled: false
 })
 
 /* state */
@@ -131,6 +149,8 @@ const isOpen = ref(false)
 const selected = ref<'none' | 'write' | 'write-prepare'>('none')
 const btnWrapper = ref<HTMLElement | null>(null)
 const hovering = ref(false)
+
+const hasCta = computed(() => Boolean(props.cta))
 
 /* interactions */
 function toggleMenu() {
@@ -175,6 +195,12 @@ const buttonLabel = computed(() => {
   if (selected.value === 'write') return 'Écrit ✔'
   if (selected.value === 'write-prepare') return 'Écrit & Préparé ✔'
   return 'Actions'
+})
+
+const ctaButtonClass = computed(() => {
+  const base = 'bg-slate-700 text-white hover:bg-slate-600 disabled:bg-slate-600/70 disabled:text-slate-200/70 disabled:cursor-not-allowed'
+  const secondary = 'bg-white/10 text-slate-100 hover:bg-white/20 disabled:bg-white/10 disabled:text-slate-200/70 disabled:cursor-not-allowed'
+  return props.ctaVariant === 'secondary' ? secondary : base
 })
 
 /* CARD classes:


### PR DESCRIPTION
## Summary
- replace BonomeWizard selection wrappers so CardArticleSpells handles option CTAs directly
- extend CardArticleSpells with a reusable CTA button that emits a select event alongside existing actions
- surface selection state and disabled styling via the card CTA to preserve accessibility and scrolling behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8df366ac832ab77f9039df0cd8b7