### PR TITLE
Add granular identity fields to bonome creation flow

### DIFF
--- a/components/BonomePreviewPanel.vue
+++ b/components/BonomePreviewPanel.vue
@@ -13,9 +13,15 @@
           </div>
         </div>
         <div class="flex-1 space-y-4">
-          <div>
+          <div class="space-y-2">
             <div class="text-xs uppercase tracking-wide text-gray-500">Nom du personnage</div>
             <div class="text-xl font-semibold text-slate-900">{{ displayCharacterName }}</div>
+            <div v-if="hasNameParts" class="space-y-1 text-sm text-slate-600">
+              <p v-if="trimmedFirstName"><span class="font-medium text-slate-700">Prénom :</span> {{ trimmedFirstName }}</p>
+              <p v-if="trimmedLastName"><span class="font-medium text-slate-700">Nom :</span> {{ trimmedLastName }}</p>
+              <p v-if="trimmedNickname"><span class="font-medium text-slate-700">Surnom :</span> {{ trimmedNickname }}</p>
+            </div>
+            <p v-else-if="trimmedFullName" class="text-sm text-slate-600">Nom complet : {{ trimmedFullName }}</p>
           </div>
           <div class="grid gap-3 sm:grid-cols-2">
             <article
@@ -156,7 +162,28 @@ const router = useRouter();
 const creation = useBonomeCreationStore();
 const personnageStore = usePersonnage();
 
-const { preview, identitySummary, displayCharacterName, previewPortrait, displayStats } = storeToRefs(creation);
+const {
+  preview,
+  identitySummary,
+  displayCharacterName,
+  previewPortrait,
+  displayStats,
+  firstName,
+  lastName,
+  nickname,
+  fullCharacterName
+} = storeToRefs(creation);
+
+const trimmedFirstName = computed(() => firstName.value.trim());
+const trimmedLastName = computed(() => lastName.value.trim());
+const trimmedNickname = computed(() => nickname.value.trim());
+const hasNameParts = computed(
+  () =>
+    Boolean(trimmedFirstName.value) ||
+    Boolean(trimmedLastName.value) ||
+    Boolean(trimmedNickname.value)
+);
+const trimmedFullName = computed(() => fullCharacterName.value.trim());
 
 const canSave = computed(() => preview.value?.ok && !(preview.value?.errors?.length));
 const saving = ref(false);

--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -42,22 +42,57 @@
       v-if="isCurrentStep('identity')"
       class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
     >
-      <div class="grid gap-4 md:grid-cols-2">
-        <div>
-          <label class="block text-sm font-medium text-slate-700">Nom du personnage</label>
-          <input
-            v-model="characterName"
-            type="text"
-            placeholder="Aventurier sans nom"
-            class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-          />
+      <form class="grid gap-4 md:grid-cols-2" @submit.prevent>
+        <div class="space-y-4">
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <label class="block text-sm font-medium text-slate-700">Prénom</label>
+              <input
+                v-model="firstName"
+                type="text"
+                placeholder="Ex. Lina"
+                class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-slate-700">Nom</label>
+              <input
+                v-model="lastName"
+                type="text"
+                placeholder="Ex. Morcant"
+                class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </div>
+            <div class="sm:col-span-2 lg:col-span-1">
+              <label class="block text-sm font-medium text-slate-700">Surnom</label>
+              <input
+                v-model="nickname"
+                type="text"
+                placeholder="Ex. L'Éclair"
+                class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+              <p class="mt-1 text-xs text-slate-500">Optionnel : sera affiché entre guillemets.</p>
+            </div>
+          </div>
         </div>
         <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
           <p class="font-semibold text-slate-700">Aperçu rapide</p>
-          <p class="mt-2">Nom affiché : {{ displayCharacterName }}</p>
-          <p>Portrait généré : {{ displayCharacterName }}</p>
+          <dl class="mt-2 space-y-2">
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Nom complet</dt>
+              <dd class="text-sm text-slate-700">{{ fullNamePreview || '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Nom affiché</dt>
+              <dd class="text-sm text-slate-700">{{ displayCharacterName }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Portrait généré</dt>
+              <dd class="text-sm text-slate-700">{{ displayCharacterName }}</dd>
+            </div>
+          </dl>
         </div>
-      </div>
+      </form>
 
       <div v-if="backgroundGroup" class="space-y-4">
         <div class="flex items-center justify-between">
@@ -497,10 +532,16 @@ const {
   selectedRace,
   selectedBackground,
   characterName,
+  firstName,
+  lastName,
+  nickname,
+  fullCharacterName,
   identitySummary,
   displayCharacterName,
   displayStats
 } = storeToRefs(creation);
+
+const fullNamePreview = computed(() => fullCharacterName.value.trim());
 
 const baseStats = creation.baseStats;
 const materialNotes = ref('');
@@ -522,6 +563,9 @@ const refreshPreview = async () => {
 
 const resetIdentity = async () => {
   characterName.value = '';
+  firstName.value = '';
+  lastName.value = '';
+  nickname.value = '';
   selectedBackground.value = '';
   await refreshPreview();
 };

--- a/stores/bonomeCreation.ts
+++ b/stores/bonomeCreation.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, ref } from 'vue';
+import { useNuxtApp } from '#app';
 import type { Personnage } from './personnage';
 
 import { usePersonnage, type Personnage } from './personnage';
@@ -322,6 +323,11 @@ const formatChoiceValue = (key: string, value: any, options: ChoiceOption[]): st
   return toLabel(value);
 };
 
+const useRequestFetch = () => {
+  const nuxtApp = useNuxtApp();
+  return nuxtApp.$fetch;
+};
+
 export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
   const requestFetch = useRequestFetch();
 
@@ -335,6 +341,9 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
   const niveau = ref<number>(1);
   const loading = ref(false);
   const characterName = ref<string>('');
+  const firstName = ref<string>('');
+  const lastName = ref<string>('');
+  const nickname = ref<string>('');
 
   const preview = ref<any | null>(null);
   const rawText = ref<string>('');
@@ -402,7 +411,30 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     })
   );
 
+  const normalizeNamePart = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+  const fullCharacterName = computed(() => {
+    const first = normalizeNamePart(firstName.value);
+    const last = normalizeNamePart(lastName.value);
+    const nick = normalizeNamePart(nickname.value);
+
+    const segments: string[] = [];
+    if (first.length) segments.push(first);
+    if (last.length) segments.push(last);
+
+    const base = segments.join(' ').trim();
+    if (nick.length) {
+      return base.length ? `${base} « ${nick} »` : `« ${nick} »`;
+    }
+
+    return base;
+  });
+
   const displayCharacterName = computed(() => {
+    const full = fullCharacterName.value.trim();
+    if (full.length) {
+      return full;
+    }
     const trimmed = characterName.value.trim();
     if (trimmed.length) {
       return trimmed;
@@ -654,7 +686,10 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
       selectedRace: selectedRace.value,
       selectedBackground: selectedBackground.value,
       niveau: niveau.value,
-      characterName: characterName.value,
+      characterName: fullCharacterName.value.trim() || characterName.value,
+      firstName: firstName.value,
+      lastName: lastName.value,
+      nickname: nickname.value,
       baseStats: { ...baseStats },
       chosenOptions: JSON.parse(JSON.stringify(chosenOptions))
     };
@@ -677,6 +712,12 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
         selectedBackground.value = parsed.selectedBackground ?? selectedBackground.value;
         niveau.value = Number(parsed.niveau ?? niveau.value) || niveau.value;
         characterName.value = parsed.characterName ?? characterName.value;
+        firstName.value = parsed.firstName ?? firstName.value;
+        lastName.value = parsed.lastName ?? lastName.value;
+        nickname.value = parsed.nickname ?? nickname.value;
+        if (!firstName.value && !lastName.value && !nickname.value && parsed.characterName) {
+          firstName.value = parsed.characterName;
+        }
         if (parsed.baseStats && typeof parsed.baseStats === 'object') {
           Object.assign(baseStats, parsed.baseStats);
         }
@@ -829,7 +870,12 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     preview.value = null;
     rawText.value = '';
     try {
-      const trimmedName = characterName.value.trim();
+      const trimmedFullName = fullCharacterName.value.trim();
+      const trimmedLegacyName = characterName.value.trim();
+      const primaryName = trimmedFullName.length ? trimmedFullName : trimmedLegacyName;
+      const trimmedFirstName = normalizeNamePart(firstName.value);
+      const trimmedLastName = normalizeNamePart(lastName.value);
+      const trimmedNickname = normalizeNamePart(nickname.value);
       const body = {
         selection: {
           class: selectedClass.value || null,
@@ -840,7 +886,10 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
           chosenOptions: { ...chosenOptions }
         },
         baseCharacter: {
-          name: trimmedName.length ? trimmedName : null,
+          name: primaryName.length ? primaryName : null,
+          first_name: trimmedFirstName.length ? trimmedFirstName : null,
+          last_name: trimmedLastName.length ? trimmedLastName : null,
+          nickname: trimmedNickname.length ? trimmedNickname : null,
           base_stats_before_race: { ...baseStats }
         }
       };
@@ -928,6 +977,9 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
       delete choiceMetadata[k];
     }
     characterName.value = '';
+    firstName.value = '';
+    lastName.value = '';
+    nickname.value = '';
     await sendPreview();
   };
 
@@ -1110,6 +1162,9 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     niveau,
     loading,
     characterName,
+    firstName,
+    lastName,
+    nickname,
     preview,
     rawText,
     showRaw,
@@ -1119,6 +1174,7 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     primarySelectionGroups,
     identitySummary,
     displayCharacterName,
+    fullCharacterName,
     previewPortrait,
     getPrimarySelectedLabel,
     selectPrimaryOption,

--- a/tests/bonomeCreationStore.test.ts
+++ b/tests/bonomeCreationStore.test.ts
@@ -102,6 +102,9 @@ export async function run() {
     selectedBackground: 'sage',
     niveau: 7,
     characterName: 'Archimage',
+    firstName: 'Aldara',
+    lastName: 'Sombrelune',
+    nickname: 'La Ruse',
     baseStats: {
       strength: 12,
       dexterity: 13,
@@ -143,6 +146,9 @@ export async function run() {
     assert.equal(unwrap(store.selectedBackground), savedState.selectedBackground, 'background should be restored');
     assert.equal(unwrap(store.niveau), savedState.niveau, 'niveau should be restored');
     assert.equal(unwrap(store.characterName), savedState.characterName, 'character name should be restored');
+    assert.equal(unwrap(store.firstName), savedState.firstName, 'first name should be restored');
+    assert.equal(unwrap(store.lastName), savedState.lastName, 'last name should be restored');
+    assert.equal(unwrap(store.nickname), savedState.nickname, 'nickname should be restored');
     assert.deepEqual(
       serializeReactive(store.baseStats),
       savedState.baseStats,
@@ -190,6 +196,21 @@ export async function run() {
       savedState.characterName,
       'reloaded store should keep character name'
     );
+    assert.equal(
+      unwrap(reloadedStore.firstName),
+      savedState.firstName,
+      'reloaded store should keep first name'
+    );
+    assert.equal(
+      unwrap(reloadedStore.lastName),
+      savedState.lastName,
+      'reloaded store should keep last name'
+    );
+    assert.equal(
+      unwrap(reloadedStore.nickname),
+      savedState.nickname,
+      'reloaded store should keep nickname'
+    );
     assert.deepEqual(
       serializeReactive(reloadedStore.chosenOptions),
       savedState.chosenOptions,
@@ -200,6 +221,29 @@ export async function run() {
         unwrap(reloadedStore.races).length > 0 &&
         unwrap(reloadedStore.backgrounds).length > 0,
       'reloaded store should populate catalog entries'
+    );
+
+    const previewCall = fetchLog.find((call) => call.url === '/api/creation/preview');
+    assert.ok(previewCall, 'preview call should be logged after reload');
+    assert.equal(
+      previewCall?.options?.body?.baseCharacter?.first_name,
+      savedState.firstName,
+      'preview should include first name'
+    );
+    assert.equal(
+      previewCall?.options?.body?.baseCharacter?.last_name,
+      savedState.lastName,
+      'preview should include last name'
+    );
+    assert.equal(
+      previewCall?.options?.body?.baseCharacter?.nickname,
+      savedState.nickname,
+      'preview should include nickname'
+    );
+    assert.equal(
+      previewCall?.options?.body?.baseCharacter?.name,
+      'Aldara Sombrelune « La Ruse »',
+      'preview should include combined full name'
     );
   } finally {
     if (originalProcessClient === undefined) {


### PR DESCRIPTION
## Summary
- add first, last, and nickname fields to the bonome creation store with persistence and preview payload support
- update the identity step UI to collect the new fields and surface the combined name in the preview panel
- extend unit tests to cover restoring and sending the expanded identity data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbc486f954832a92f9ab1c4a941db7