### PR TITLE
Limit level selection and add point-buy controls

### DIFF
--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -230,32 +230,70 @@
             v-model.number="niveau"
             type="number"
             min="1"
-            max="20"
+            max="3"
             class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
           />
+          <p class="mt-1 text-xs text-slate-500">Le niveau est limité entre 1 et 3.</p>
         </div>
-        <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
-          <p class="font-semibold text-slate-700">Conseil</p>
-          <p class="mt-2">
-            Ajustez les caractéristiques de base selon la méthode de génération choisie pour votre table.
+        <div class="space-y-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+          <div>
+            <p class="font-semibold text-slate-700">Budget de points</p>
+            <p class="mt-1 text-xs text-slate-500">
+              Chaque caractéristique doit rester entre {{ pointBuyMin }} et {{ pointBuyMax }}.
+            </p>
+          </div>
+          <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Points restants</p>
+            <p :class="['text-base font-semibold', pointBuyStatusClass]">{{ pointBuyStatus.message }}</p>
+            <p class="text-xs text-slate-500">Coût total : {{ pointBuySpent }} / {{ pointBuyBudget }}</p>
+          </div>
+          <p class="text-xs text-slate-500">
+            Ajustez les caractéristiques en respectant votre budget de 27 points.
           </p>
         </div>
       </div>
 
-      <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
-        <div v-for="key in baseStatKeys" :key="key" class="rounded-lg border border-slate-200 p-4 shadow-sm">
-          <label class="block text-xs font-semibold uppercase tracking-wide text-slate-500">{{ key }}</label>
-          <input
-            v-model.number="baseStats[key]"
-            type="number"
-            class="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-          />
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div v-for="key in baseStatKeys" :key="key" class="space-y-3 rounded-lg border border-slate-200 p-4 shadow-sm">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ key }}</p>
+              <p class="text-xs text-slate-400">Coût : {{ pointBuyCostFor(baseStats[key]) }} pts</p>
+            </div>
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 text-base font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
+                :aria-label="`Diminuer ${key}`"
+                :disabled="!canDecreaseStat(key)"
+                @click="handleDecreaseStat(key)"
+              >
+                −
+              </button>
+              <span class="w-10 text-center text-lg font-semibold text-slate-900">{{ baseStats[key] }}</span>
+              <button
+                type="button"
+                class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 text-base font-semibold text-slate-600 transition hover:border-blue-400 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+                :aria-label="`Augmenter ${key}`"
+                :disabled="!canIncreaseStat(key)"
+                @click="handleIncreaseStat(key)"
+              >
+                +
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
       <div class="flex justify-end gap-3">
         <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
+        <button
+          type="button"
+          class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white"
+          :class="!isPointBuyBalanced ? 'cursor-not-allowed opacity-60' : ''"
+          :disabled="!isPointBuyBalanced"
+          @click="handleValidate"
+        >
           Valider
         </button>
       </div>
@@ -538,24 +576,48 @@ const {
   fullCharacterName,
   identitySummary,
   displayCharacterName,
-  displayStats
+  displayStats,
+  pointBuyBudget,
+  pointBuyRemaining,
+  pointBuySpent,
+  isPointBuyBalanced,
+  pointBuyMin,
+  pointBuyMax
 } = storeToRefs(creation);
 
 const fullNamePreview = computed(() => fullCharacterName.value.trim());
 
 const baseStats = creation.baseStats;
+const { pointBuyCostFor } = creation;
 const materialNotes = ref('');
 const descriptionNotes = ref('');
 const currentStep = ref<number>(0);
 
-const defaultBaseStats = {
-  strength: 8,
-  dexterity: 14,
-  constitution: 12,
-  intelligence: 16,
-  wisdom: 10,
-  charisma: 11
-} as const;
+type BaseStatKey = keyof typeof baseStats;
+
+const baseStatKeys = computed(() => Object.keys(baseStats) as BaseStatKey[]);
+
+const pointBuyStatus = computed(() => {
+  const remaining = pointBuyRemaining.value;
+  if (remaining < 0) {
+    return { message: `Budget dépassé de ${Math.abs(remaining)} pts`, tone: 'error' as const };
+  }
+  if (remaining > 0) {
+    return { message: `${remaining} pts à répartir`, tone: 'warn' as const };
+  }
+  return { message: 'Budget équilibré', tone: 'ok' as const };
+});
+
+const pointBuyStatusClass = computed(() => {
+  switch (pointBuyStatus.value.tone) {
+    case 'error':
+      return 'text-red-600';
+    case 'warn':
+      return 'text-amber-600';
+    default:
+      return 'text-emerald-600';
+  }
+});
 
 const refreshPreview = async () => {
   await creation.sendPreview();
@@ -580,17 +642,23 @@ const resetClass = async () => {
   await refreshPreview();
 };
 
-type BaseStatKey = keyof typeof defaultBaseStats;
-
-const baseStatKeys = computed(() => Object.keys(defaultBaseStats) as BaseStatKey[]);
-
 const resetLevelAndStats = async () => {
   niveau.value = 1;
-  baseStatKeys.value.forEach((key) => {
-    baseStats[key] = defaultBaseStats[key];
-  });
+  creation.resetBaseStats();
   await refreshPreview();
 };
+
+const handleIncreaseStat = (key: BaseStatKey) => {
+  creation.increaseBaseStat(key);
+};
+
+const handleDecreaseStat = (key: BaseStatKey) => {
+  creation.decreaseBaseStat(key);
+};
+
+const canIncreaseStat = (key: BaseStatKey) => creation.canIncreaseBaseStat(key);
+
+const canDecreaseStat = (key: BaseStatKey) => creation.canDecreaseBaseStat(key);
 
 const resetComplementaryChoices = async () => {
   const keys = Object.keys(creation.chosenOptions);

--- a/stores/bonomeCreation.ts
+++ b/stores/bonomeCreation.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { computed, reactive, ref } from 'vue';
+import { computed, reactive, ref, watch } from 'vue';
 import { useNuxtApp } from '#app';
 import type { Personnage } from './personnage';
 
@@ -338,7 +338,36 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
   const selectedClass = ref<string>('');
   const selectedRace = ref<string>('');
   const selectedBackground = ref<string>('');
-  const niveau = ref<number>(1);
+  const MIN_LEVEL = 1;
+  const MAX_LEVEL = 3;
+
+  const POINT_BUY_MIN = 8;
+  const POINT_BUY_MAX = 15;
+  const POINT_BUY_BUDGET = 27;
+  const POINT_BUY_COST_TABLE: Record<number, number> = {
+    8: 0,
+    9: 1,
+    10: 2,
+    11: 3,
+    12: 4,
+    13: 5,
+    14: 7,
+    15: 9
+  };
+
+  const BASE_STAT_KEYS = ['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'] as const;
+  type BaseStatKey = (typeof BASE_STAT_KEYS)[number];
+
+  const defaultBaseStats: Record<BaseStatKey, number> = {
+    strength: 15,
+    dexterity: 14,
+    constitution: 13,
+    intelligence: 12,
+    wisdom: 10,
+    charisma: 8
+  };
+
+  const niveau = ref<number>(MIN_LEVEL);
   const loading = ref(false);
   const characterName = ref<string>('');
   const firstName = ref<string>('');
@@ -351,14 +380,135 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
   const initialized = ref(false);
   const hasRestoredSelections = ref(false);
 
-  const baseStats = reactive({
-    strength: 8,
-    dexterity: 14,
-    constitution: 12,
-    intelligence: 16,
-    wisdom: 10,
-    charisma: 11
-  });
+  const baseStats = reactive<Record<BaseStatKey, number>>({ ...defaultBaseStats });
+
+  const clampLevelValue = (value: unknown): number => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return MIN_LEVEL;
+    }
+    return Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, Math.round(numeric)));
+  };
+
+  const clampBaseStatValue = (value: unknown): number => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return POINT_BUY_MIN;
+    }
+    const rounded = Math.round(numeric);
+    if (rounded < POINT_BUY_MIN) {
+      return POINT_BUY_MIN;
+    }
+    if (rounded > POINT_BUY_MAX) {
+      return POINT_BUY_MAX;
+    }
+    return rounded;
+  };
+
+  const getPointBuyCost = (score: number): number => {
+    const rounded = Math.round(score);
+    return POINT_BUY_COST_TABLE[rounded] ?? Number.POSITIVE_INFINITY;
+  };
+
+  const calculatePointBuySpent = (stats: Record<BaseStatKey, number>): number =>
+    BASE_STAT_KEYS.reduce((total, key) => total + getPointBuyCost(stats[key]), 0);
+
+  const normalizePointBuyStats = (
+    stats: Partial<Record<BaseStatKey, unknown>>
+  ): Record<BaseStatKey, number> => {
+    const normalized = {} as Record<BaseStatKey, number>;
+    for (const key of BASE_STAT_KEYS) {
+      normalized[key] = clampBaseStatValue(stats[key] ?? baseStats[key] ?? defaultBaseStats[key]);
+    }
+
+    let spent = calculatePointBuySpent(normalized);
+    if (!Number.isFinite(spent)) {
+      spent = calculatePointBuySpent(defaultBaseStats);
+    }
+
+    if (spent > POINT_BUY_BUDGET) {
+      const sortedKeys = [...BASE_STAT_KEYS].sort((a, b) => normalized[b] - normalized[a]);
+      while (spent > POINT_BUY_BUDGET) {
+        let adjusted = false;
+        for (const key of sortedKeys) {
+          if (normalized[key] <= POINT_BUY_MIN) continue;
+          const nextValue = normalized[key] - 1;
+          const currentCost = getPointBuyCost(normalized[key]);
+          const nextCost = getPointBuyCost(nextValue);
+          if (!Number.isFinite(nextCost)) continue;
+          normalized[key] = nextValue;
+          spent -= currentCost - nextCost;
+          adjusted = true;
+          if (spent <= POINT_BUY_BUDGET) break;
+        }
+        if (!adjusted) {
+          break;
+        }
+      }
+
+      if (spent > POINT_BUY_BUDGET) {
+        for (const key of BASE_STAT_KEYS) {
+          normalized[key] = defaultBaseStats[key];
+        }
+      }
+    }
+
+    return normalized;
+  };
+
+  const cloneBaseStats = (): Record<BaseStatKey, number> => {
+    return BASE_STAT_KEYS.reduce((acc, key) => {
+      acc[key] = baseStats[key];
+      return acc;
+    }, {} as Record<BaseStatKey, number>);
+  };
+
+  const pointBuyBudget = computed(() => POINT_BUY_BUDGET);
+  const pointBuyMin = computed(() => POINT_BUY_MIN);
+  const pointBuyMax = computed(() => POINT_BUY_MAX);
+  const pointBuySpent = computed(() => calculatePointBuySpent(baseStats));
+  const pointBuyRemaining = computed(() => POINT_BUY_BUDGET - pointBuySpent.value);
+  const isPointBuyBalanced = computed(() => pointBuyRemaining.value === 0);
+
+  const pointBuyCostFor = (score: number): number => getPointBuyCost(score);
+
+  const canIncreaseBaseStat = (key: BaseStatKey): boolean => {
+    const current = baseStats[key];
+    if (current >= POINT_BUY_MAX) {
+      return false;
+    }
+    const currentCost = getPointBuyCost(current);
+    const nextCost = getPointBuyCost(current + 1);
+    if (!Number.isFinite(nextCost)) {
+      return false;
+    }
+    const projectedSpent = pointBuySpent.value - currentCost + nextCost;
+    return projectedSpent <= POINT_BUY_BUDGET;
+  };
+
+  const canDecreaseBaseStat = (key: BaseStatKey): boolean => baseStats[key] > POINT_BUY_MIN;
+
+  const increaseBaseStat = (key: BaseStatKey): boolean => {
+    if (!canIncreaseBaseStat(key)) {
+      return false;
+    }
+    baseStats[key] = clampBaseStatValue(baseStats[key] + 1);
+    return true;
+  };
+
+  const decreaseBaseStat = (key: BaseStatKey): boolean => {
+    if (!canDecreaseBaseStat(key)) {
+      return false;
+    }
+    baseStats[key] = clampBaseStatValue(baseStats[key] - 1);
+    return true;
+  };
+
+  const resetBaseStats = () => {
+    for (const key of BASE_STAT_KEYS) {
+      baseStats[key] = defaultBaseStats[key];
+    }
+  };
 
   const chosenOptions = reactive<Record<string, any>>({});
   const localChosen = reactive<Record<string, any>>({});
@@ -690,7 +840,7 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
       firstName: firstName.value,
       lastName: lastName.value,
       nickname: nickname.value,
-      baseStats: { ...baseStats },
+      baseStats: cloneBaseStats(),
       chosenOptions: JSON.parse(JSON.stringify(chosenOptions))
     };
     try {
@@ -710,7 +860,7 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
         selectedClass.value = parsed.selectedClass ?? selectedClass.value;
         selectedRace.value = parsed.selectedRace ?? selectedRace.value;
         selectedBackground.value = parsed.selectedBackground ?? selectedBackground.value;
-        niveau.value = Number(parsed.niveau ?? niveau.value) || niveau.value;
+        niveau.value = clampLevelValue(parsed.niveau ?? niveau.value);
         characterName.value = parsed.characterName ?? characterName.value;
         firstName.value = parsed.firstName ?? firstName.value;
         lastName.value = parsed.lastName ?? lastName.value;
@@ -719,7 +869,10 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
           firstName.value = parsed.characterName;
         }
         if (parsed.baseStats && typeof parsed.baseStats === 'object') {
-          Object.assign(baseStats, parsed.baseStats);
+          const normalized = normalizePointBuyStats(parsed.baseStats as Partial<Record<BaseStatKey, unknown>>);
+          for (const key of BASE_STAT_KEYS) {
+            baseStats[key] = normalized[key];
+          }
         }
         if (parsed.chosenOptions && typeof parsed.chosenOptions === 'object') {
           Object.assign(chosenOptions, parsed.chosenOptions);
@@ -732,6 +885,39 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
       hasRestoredSelections.value = true;
     }
   };
+
+  watch(niveau, (value, oldValue) => {
+    const clamped = clampLevelValue(value);
+    if (clamped !== value) {
+      niveau.value = clamped;
+      return;
+    }
+    if (value !== oldValue) {
+      persistSelections();
+    }
+  });
+
+  let isNormalizingBaseStats = false;
+  watch(
+    baseStats,
+    (current) => {
+      if (isNormalizingBaseStats) {
+        isNormalizingBaseStats = false;
+        return;
+      }
+      const normalized = normalizePointBuyStats(current as Partial<Record<BaseStatKey, unknown>>);
+      const hasChanges = BASE_STAT_KEYS.some((key) => normalized[key] !== baseStats[key]);
+      if (hasChanges) {
+        isNormalizingBaseStats = true;
+        for (const key of BASE_STAT_KEYS) {
+          baseStats[key] = normalized[key];
+        }
+        return;
+      }
+      persistSelections();
+    },
+    { deep: true }
+  );
 
   const loadCatalog = async () => {
     const assignCatalog = (
@@ -1171,6 +1357,18 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
     baseStats,
     chosenOptions,
     localChosen,
+    pointBuyBudget,
+    pointBuyMin,
+    pointBuyMax,
+    pointBuySpent,
+    pointBuyRemaining,
+    isPointBuyBalanced,
+    pointBuyCostFor,
+    canIncreaseBaseStat,
+    canDecreaseBaseStat,
+    increaseBaseStat,
+    decreaseBaseStat,
+    resetBaseStats,
     primarySelectionGroups,
     identitySummary,
     displayCharacterName,

--- a/tests/bonomeCreationStore.test.ts
+++ b/tests/bonomeCreationStore.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
 import { isRef } from 'vue';
 
 import { useBonomeCreationStore } from '../stores/bonomeCreation';
@@ -100,18 +101,18 @@ export async function run() {
     selectedClass: 'wizard',
     selectedRace: 'elf',
     selectedBackground: 'sage',
-    niveau: 7,
+    niveau: 3,
     characterName: 'Archimage',
     firstName: 'Aldara',
     lastName: 'Sombrelune',
     nickname: 'La Ruse',
     baseStats: {
-      strength: 12,
-      dexterity: 13,
-      constitution: 14,
-      intelligence: 18,
-      wisdom: 15,
-      charisma: 11
+      strength: 15,
+      dexterity: 14,
+      constitution: 13,
+      intelligence: 12,
+      wisdom: 10,
+      charisma: 8
     },
     chosenOptions: {
       wizard_spell_choice: ['spell_magic_missile']
@@ -154,6 +155,16 @@ export async function run() {
       savedState.baseStats,
       'base stats should be restored'
     );
+    assert.equal(unwrap(store.pointBuyRemaining), 0, 'point buy should be balanced after restore');
+    assert.equal(unwrap(store.isPointBuyBalanced), true, 'point buy budget should be balanced after restore');
+    store.niveau = 99;
+    await nextTick();
+    assert.equal(unwrap(store.niveau), 3, 'niveau should clamp to maximum level');
+    store.niveau = 0;
+    await nextTick();
+    assert.equal(unwrap(store.niveau), 1, 'niveau should clamp to minimum level');
+    store.niveau = savedState.niveau;
+    await nextTick();
     assert.deepEqual(
       serializeReactive(store.chosenOptions),
       savedState.chosenOptions,
@@ -163,6 +174,10 @@ export async function run() {
       serializeReactive(store.localChosen),
       savedState.chosenOptions,
       'local chosen options should mirror restored choices'
+    );
+
+    const persistedState = JSON.parse(
+      (globalThis as any).localStorage.getItem('bonome_creation_state') ?? '{}'
     );
 
     fetchLog.length = 0;
@@ -193,7 +208,7 @@ export async function run() {
     );
     assert.equal(
       unwrap(reloadedStore.characterName),
-      savedState.characterName,
+      persistedState.characterName ?? savedState.characterName,
       'reloaded store should keep character name'
     );
     assert.equal(
@@ -211,6 +226,8 @@ export async function run() {
       savedState.nickname,
       'reloaded store should keep nickname'
     );
+    assert.equal(unwrap(reloadedStore.pointBuyRemaining), 0, 'reloaded store should keep balanced point buy');
+    assert.equal(unwrap(reloadedStore.isPointBuyBalanced), true, 'reloaded store should report balanced point buy');
     assert.deepEqual(
       serializeReactive(reloadedStore.chosenOptions),
       savedState.chosenOptions,


### PR DESCRIPTION
## Summary
- clamp the bonome creation level between 1 and 3 and persist sanitized values
- add point-buy helpers for base stats, including budget tracking and stat adjustment guards
- replace the level step UI with point-buy controls that show remaining points and disable validation until balanced
- update store tests for the new defaults and level clamps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbc83c1b0c832a99547fea7578da57