### PR TITLE
Refactor Bonome wizard into modular phase components

### DIFF
--- a/components/BonomePhase1.vue
+++ b/components/BonomePhase1.vue
@@ -1,0 +1,86 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <form class="grid gap-6 md:grid-cols-2" @submit.prevent>
+      <div class="space-y-4">
+        <div>
+          <label class="block text-sm font-medium text-slate-700">Prénom</label>
+          <input
+            v-model="characterFirstName"
+            type="text"
+            placeholder="Ex. Lina"
+            class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700">Nom</label>
+          <input
+            v-model="characterLastName"
+            type="text"
+            placeholder="Ex. Morcant"
+            class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700">Surnom</label>
+          <input
+            v-model="characterNickname"
+            type="text"
+            placeholder="Ex. L'Éclair"
+            class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+          />
+          <p class="mt-1 text-xs text-slate-500">Optionnel : sera affiché entre guillemets.</p>
+        </div>
+      </div>
+      <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+        <p class="font-semibold text-slate-700">Aperçu rapide</p>
+        <dl class="mt-2 space-y-2">
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Nom complet</dt>
+            <dd class="text-sm text-slate-700">{{ fullNamePreview || '—' }}</dd>
+          </div>
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Nom affiché</dt>
+            <dd class="text-sm text-slate-700">{{ displayCharacterName }}</dd>
+          </div>
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Portrait généré</dt>
+            <dd class="text-sm text-slate-700">{{ displayCharacterName }}</dd>
+          </div>
+        </dl>
+      </div>
+    </form>
+
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import { useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées décrivant l'étape courante (identifiant, libellés, actions associées).
+   */
+  stepMeta: BonomePhaseMeta;
+}>();
+
+const creation = useBonomeCreationStore();
+const { characterFirstName, characterLastName, characterNickname, fullCharacterName, displayCharacterName } =
+  storeToRefs(creation);
+
+const fullNamePreview = computed(() => fullCharacterName.value.trim());
+
+// Ensure props are referenced to avoid unused warnings in template compilation.
+const stepMeta = computed(() => props.stepMeta);
+</script>

--- a/components/BonomePhase2.vue
+++ b/components/BonomePhase2.vue
@@ -1,0 +1,72 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <div class="space-y-2">
+      <h3 class="text-lg font-semibold text-slate-900">Choix de la race</h3>
+      <p class="text-sm text-slate-600">Sélectionnez la race correspondant à votre personnage.</p>
+    </div>
+    <div v-if="raceGroup" class="-mx-1 px-1">
+      <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+        <CardArticleSpells
+          v-for="option in raceGroup.options"
+          :key="option.id"
+          :title="option.label"
+          :description="option.description"
+          :effact-label="option.effectLabel ?? undefined"
+          :image="option.image"
+          role="option"
+          :aria-selected="raceGroup.selected === option.id"
+          :selection-state="raceGroup.selected === option.id ? 'write' : 'none'"
+          :class="[
+            'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+            raceGroup.selected === option.id ? 'ring-2 ring-blue-500 border-blue-500 shadow-md' : 'hover:border-slate-300 hover:shadow'
+          ]"
+          @write="selectPrimaryOption('race', option.id)"
+          @write-prepare="selectPrimaryOption('race', option.id)"
+          @reset="resetPrimarySelection(option.id)"
+        />
+      </div>
+    </div>
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import CardArticleSpells from '@/components/CardArticleSpells.vue';
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import type { PrimarySelectionGroup } from '@/stores/bonomeCreation';
+import { useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées de l'étape (utilisées pour la navigation et l'accessibilité).
+   */
+  stepMeta: BonomePhaseMeta;
+  /**
+   * Groupe de sélection des races fourni par l'assistant (options et sélection courante).
+   */
+  raceGroup: PrimarySelectionGroup | null;
+}>();
+
+const creation = useBonomeCreationStore();
+const { selectedRace } = storeToRefs(creation);
+const { selectPrimaryOption } = creation;
+
+const resetPrimarySelection = (optionId: string) => {
+  if (selectedRace.value === optionId) {
+    selectedRace.value = '';
+  }
+};
+
+const stepMeta = computed(() => props.stepMeta);
+const raceGroup = computed(() => props.raceGroup);
+</script>

--- a/components/BonomePhase3.vue
+++ b/components/BonomePhase3.vue
@@ -1,0 +1,74 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <div class="space-y-2">
+      <h3 class="text-lg font-semibold text-slate-900">Choix de la classe</h3>
+      <p class="text-sm text-slate-600">Sélectionnez la classe principale de votre bonôme.</p>
+    </div>
+    <div v-if="classGroup" class="-mx-1 px-1">
+      <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+        <CardArticleSpells
+          v-for="option in classGroup.options"
+          :key="option.id"
+          :title="option.label"
+          :description="option.description"
+          :effact-label="option.effectLabel ?? undefined"
+          :image="option.image"
+          role="option"
+          :aria-selected="classGroup.selected === option.id"
+          :selection-state="classGroup.selected === option.id ? 'write' : 'none'"
+          :class="[
+            'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+            classGroup.selected === option.id
+              ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
+              : 'hover:border-slate-300 hover:shadow'
+          ]"
+          @write="selectPrimaryOption('class', option.id)"
+          @write-prepare="selectPrimaryOption('class', option.id)"
+          @reset="resetPrimarySelection(option.id)"
+        />
+      </div>
+    </div>
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import CardArticleSpells from '@/components/CardArticleSpells.vue';
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import type { PrimarySelectionGroup } from '@/stores/bonomeCreation';
+import { useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées de l'étape courante.
+   */
+  stepMeta: BonomePhaseMeta;
+  /**
+   * Groupe des classes primaires disponible et sélection en cours.
+   */
+  classGroup: PrimarySelectionGroup | null;
+}>();
+
+const creation = useBonomeCreationStore();
+const { selectedClass } = storeToRefs(creation);
+const { selectPrimaryOption } = creation;
+
+const resetPrimarySelection = (optionId: string) => {
+  if (selectedClass.value === optionId) {
+    selectedClass.value = '';
+  }
+};
+
+const stepMeta = computed(() => props.stepMeta);
+const classGroup = computed(() => props.classGroup);
+</script>

--- a/components/BonomePhase4.vue
+++ b/components/BonomePhase4.vue
@@ -1,0 +1,148 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <div class="grid gap-6 md:grid-cols-2">
+      <div>
+        <label class="block text-sm font-medium text-slate-700">Niveau</label>
+        <input
+          v-model.number="niveau"
+          type="number"
+          min="1"
+          max="3"
+          class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+        />
+        <p class="mt-1 text-xs text-slate-500">Le niveau est limité entre 1 et 3.</p>
+      </div>
+      <div class="space-y-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+        <div>
+          <p class="font-semibold text-slate-700">Budget de points</p>
+          <p class="mt-1 text-xs text-slate-500">
+            Chaque caractéristique doit rester entre {{ pointBuyMin }} et {{ pointBuyMax }}.
+          </p>
+        </div>
+        <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Points restants</p>
+          <p :class="['text-base font-semibold', pointBuyStatusClass]">{{ pointBuyStatus.message }}</p>
+          <p class="text-xs text-slate-500">Coût total : {{ pointBuySpent }} / {{ pointBuyBudget }}</p>
+        </div>
+        <p class="text-xs text-slate-500">
+          Ajustez les caractéristiques en respectant votre budget de 27 points.
+        </p>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div v-for="key in baseStatKeys" :key="key" class="space-y-3 rounded-lg border border-slate-200 p-4 shadow-sm">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ key }}</p>
+            <p class="text-xs text-slate-400">Coût : {{ pointBuyCostFor(baseStats[key]) }} pts</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 text-base font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
+              :aria-label="`Diminuer ${key}`"
+              :disabled="!canDecreaseStat(key)"
+              @click="handleDecreaseStat(key)"
+            >
+              −
+            </button>
+            <span class="w-10 text-center text-lg font-semibold text-slate-900">{{ baseStats[key] }}</span>
+            <button
+              type="button"
+              class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 text-base font-semibold text-slate-600 transition hover:border-blue-400 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+              :aria-label="`Augmenter ${key}`"
+              :disabled="!canIncreaseStat(key)"
+              @click="handleIncreaseStat(key)"
+            >
+              +
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button
+        type="button"
+        class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white"
+        :class="!isPointBuyBalanced ? 'cursor-not-allowed opacity-60' : ''"
+        :disabled="!isPointBuyBalanced"
+        @click="emit('validate')"
+      >
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import { useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Informations d'étape utilisées pour la navigation.
+   */
+  stepMeta: BonomePhaseMeta;
+}>();
+
+const creation = useBonomeCreationStore();
+const {
+  niveau,
+  pointBuyBudget,
+  pointBuyRemaining,
+  pointBuySpent,
+  isPointBuyBalanced,
+  pointBuyMin,
+  pointBuyMax
+} = storeToRefs(creation);
+
+const baseStats = creation.baseStats;
+const { pointBuyCostFor } = creation;
+
+type BaseStatKey = keyof typeof baseStats;
+
+const baseStatKeys = computed(() => Object.keys(baseStats) as BaseStatKey[]);
+
+const pointBuyStatus = computed(() => {
+  const remaining = pointBuyRemaining.value;
+  if (remaining < 0) {
+    return { message: `Budget dépassé de ${Math.abs(remaining)} pts`, tone: 'error' as const };
+  }
+  if (remaining > 0) {
+    return { message: `${remaining} pts à répartir`, tone: 'warn' as const };
+  }
+  return { message: 'Budget équilibré', tone: 'ok' as const };
+});
+
+const pointBuyStatusClass = computed(() => {
+  switch (pointBuyStatus.value.tone) {
+    case 'error':
+      return 'text-red-600';
+    case 'warn':
+      return 'text-amber-600';
+    default:
+      return 'text-emerald-600';
+  }
+});
+
+const handleIncreaseStat = (key: BaseStatKey) => {
+  creation.increaseBaseStat(key);
+};
+
+const handleDecreaseStat = (key: BaseStatKey) => {
+  creation.decreaseBaseStat(key);
+};
+
+const canIncreaseStat = (key: BaseStatKey) => creation.canIncreaseBaseStat(key);
+const canDecreaseStat = (key: BaseStatKey) => creation.canDecreaseBaseStat(key);
+
+const stepMeta = computed(() => props.stepMeta);
+</script>

--- a/components/BonomePhase5.vue
+++ b/components/BonomePhase5.vue
@@ -1,0 +1,170 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <div class="space-y-2">
+      <h3 class="text-lg font-semibold text-slate-900">Choix complémentaires</h3>
+      <p class="text-sm text-slate-600">Appliquez les options supplémentaires proposées par l'assistant.</p>
+    </div>
+
+    <section v-if="preview && preview.pendingChoices && preview.pendingChoices.length" class="space-y-4">
+      <article
+        v-for="(choice, idx) in preview.pendingChoices"
+        :key="getChoiceKey(choice, idx) ?? idx"
+        class="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+      >
+        <header class="flex flex-col gap-2 border-b border-slate-100 pb-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h4 class="text-base font-semibold text-slate-900">{{ getChoiceTitle(choice) }}</h4>
+            <p class="text-xs text-slate-500">
+              Choisir {{ getChoiceRequirement(choice) }} / catégorie : {{ getChoiceCategoryLabel(choice) }}
+            </p>
+          </div>
+          <span class="text-xs font-medium uppercase tracking-wide text-slate-400">
+            Source : {{ getChoiceSourceLabel(choice) }}
+          </span>
+        </header>
+
+        <div class="space-y-4">
+          <div v-if="getChoiceOptions(choice).length" class="-mx-1 px-1">
+            <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+              <CardArticleSpells
+                v-for="(opt, optIdx) in getChoiceOptions(choice)"
+                :key="typeof opt.value === 'object' ? optIdx : (opt.value ?? optIdx)"
+                :title="opt.label"
+                :description="getChoiceOptionDescription(opt)"
+                :effact-label="opt.effectLabel ?? opt.effect_label ?? undefined"
+                :image="getChoiceOptionImage(opt)"
+                role="option"
+                :aria-selected="isChoiceOptionSelected(choice, opt)"
+                :selection-state="isChoiceOptionSelected(choice, opt) ? 'write' : 'none'"
+                :class="[
+                  'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+                  isChoiceOptionSelected(choice, opt)
+                    ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
+                    : 'hover:border-slate-300 hover:shadow',
+                  isChoiceOptionDisabled(choice, opt) ? 'cursor-not-allowed opacity-60' : ''
+                ]"
+                @write="handleChoiceOptionClick(choice, opt)"
+                @write-prepare="handleChoiceOptionClick(choice, opt)"
+                @reset="resetChoiceOption(choice, opt)"
+              />
+            </div>
+          </div>
+          <p v-else class="text-sm italic text-slate-500">
+            Aucune option lisible pour ce choix (vérifier la donnée).
+          </p>
+
+          <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
+            <span>
+              Sélection :
+              {{ getLocalChoiceCount(choice) }} / {{ getChoiceRequirement(choice) }}
+              <span v-if="getChoiceRequirement(choice) > 1">(sélection multiple autorisée)</span>
+            </span>
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                class="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-semibold text-white"
+                @click="applyChoice(choice)"
+              >
+                Appliquer
+              </button>
+              <button
+                type="button"
+                class="rounded-lg border border-slate-200 px-3 py-1 text-xs"
+                :disabled="!hasLocalChoiceValue(choice)"
+                @click="resetChoice(choice)"
+              >
+                Réinitialiser
+              </button>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+    <p v-else class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+      Aucun choix complémentaire requis pour le moment.
+    </p>
+
+    <section v-if="appliedChoices.length" class="space-y-3">
+      <h4 class="text-sm font-semibold text-slate-700">Choix appliqués</h4>
+      <ul class="space-y-2">
+        <li
+          v-for="choice in appliedChoices"
+          :key="choice.id"
+          class="flex items-start justify-between gap-4 rounded-lg border border-slate-200 bg-white p-3 text-sm shadow-sm"
+        >
+          <div>
+            <p class="font-semibold text-slate-800">{{ choice.label }}</p>
+            <p class="text-xs text-slate-500">{{ choice.displayValue }}</p>
+          </div>
+          <button
+            type="button"
+            class="rounded-lg border border-slate-200 px-3 py-1 text-xs"
+            @click="resetChoiceById(choice.id)"
+          >
+            Retirer
+          </button>
+        </li>
+      </ul>
+    </section>
+
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import CardArticleSpells from '@/components/CardArticleSpells.vue';
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import { useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées de l'étape courante.
+   */
+  stepMeta: BonomePhaseMeta;
+  /**
+   * Prévisualisation en cours contenant les choix à appliquer.
+   */
+  preview: any | null;
+}>();
+
+const creation = useBonomeCreationStore();
+const { appliedChoices, preview: storePreview } = storeToRefs(creation);
+
+const {
+  getChoiceKey,
+  getChoiceTitle,
+  getChoiceRequirement,
+  getChoiceCategoryLabel,
+  getChoiceSourceLabel,
+  getChoiceOptions,
+  getChoiceOptionDescription,
+  getChoiceOptionImage,
+  isChoiceOptionDisabled,
+  handleChoiceOptionClick,
+  isChoiceOptionSelected,
+  getLocalChoiceCount,
+  applyChoice,
+  resetChoice,
+  hasLocalChoiceValue,
+  resetChoiceById
+} = creation;
+
+const resetChoiceOption = (choice: any, option: any) => {
+  if (isChoiceOptionSelected(choice, option)) {
+    handleChoiceOptionClick(choice, option);
+  }
+};
+
+const stepMeta = computed(() => props.stepMeta);
+const preview = computed(() => props.preview ?? storePreview.value ?? null);
+</script>

--- a/components/BonomePhase6.vue
+++ b/components/BonomePhase6.vue
@@ -1,0 +1,79 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <div class="space-y-2">
+      <h3 class="text-lg font-semibold text-slate-900">Matériel</h3>
+      <p class="text-sm text-slate-600">
+        Réservez les emplacements clés de l’équipement : chaque bloc sera enrichi par la suite par
+        l’assistant ou vos choix manuels.
+      </p>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <article
+        v-for="slot in equipmentSlots"
+        :key="slot.id"
+        class="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+      >
+        <header class="flex items-start justify-between gap-3">
+          <div>
+            <h4 class="text-sm font-semibold text-slate-900">{{ slot.label }}</h4>
+            <p class="text-xs text-slate-500">{{ slot.hint }}</p>
+          </div>
+          <button
+            type="button"
+            class="cursor-not-allowed rounded-full border border-dashed border-slate-300 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-slate-400"
+            disabled
+          >
+            À venir
+          </button>
+        </header>
+        <input
+          v-model="materialPlan[slot.id]"
+          type="text"
+          :placeholder="slot.placeholder"
+          class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+        />
+      </article>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-slate-700">Notes complémentaires</label>
+      <textarea
+        v-model="materialPlan.notes"
+        rows="4"
+        class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+        placeholder="Consignez les ajustements libres : munitions, potions, objets uniques…"
+      ></textarea>
+      <p class="mt-1 text-xs text-slate-500">
+        Ces informations seront ajoutées à la fiche finale du personnage.
+      </p>
+    </div>
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import { MATERIAL_SLOT_DEFINITIONS, useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées d'étape pour identification.
+   */
+  stepMeta: BonomePhaseMeta;
+}>();
+
+const creation = useBonomeCreationStore();
+const materialPlan = creation.materialPlan;
+
+const equipmentSlots = MATERIAL_SLOT_DEFINITIONS;
+
+const stepMeta = computed(() => props.stepMeta);
+</script>

--- a/components/BonomePhase7.vue
+++ b/components/BonomePhase7.vue
@@ -1,0 +1,57 @@
+<template>
+  <section :data-step="stepMeta.id" class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+    <div class="space-y-2">
+      <h3 class="text-lg font-semibold text-slate-900">Description narrative</h3>
+      <p class="text-sm text-slate-600">
+        Renseignez les repères narratifs clés : ces éléments complètent la fiche pour donner vie au personnage.
+      </p>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <article
+        v-for="field in descriptionFieldDefinitions"
+        :key="field.id"
+        class="space-y-2 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+      >
+        <div>
+          <label class="block text-sm font-semibold text-slate-800">{{ field.label }}</label>
+          <p v-if="field.hint" class="mt-1 text-xs text-slate-500">{{ field.hint }}</p>
+        </div>
+        <textarea
+          v-model="descriptionFields[field.id]"
+          rows="4"
+          class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+          :placeholder="field.placeholder"
+        ></textarea>
+      </article>
+    </div>
+    <div class="flex justify-end gap-3">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
+      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+        Valider
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import { DESCRIPTION_FIELD_DEFINITIONS, useBonomeCreationStore } from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées d'étape pour contextualiser la section.
+   */
+  stepMeta: BonomePhaseMeta;
+}>();
+
+const creation = useBonomeCreationStore();
+const descriptionFields = creation.descriptionFields;
+
+const descriptionFieldDefinitions = DESCRIPTION_FIELD_DEFINITIONS;
+
+const stepMeta = computed(() => props.stepMeta);
+</script>

--- a/components/BonomePhase8.vue
+++ b/components/BonomePhase8.vue
@@ -1,0 +1,134 @@
+<template>
+  <section
+    :data-step="stepMeta.id"
+    :data-preview-ready="!!preview"
+    class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
+  >
+    <div class="space-y-3">
+      <h3 class="text-lg font-semibold text-slate-900">Récapitulatif</h3>
+      <p class="text-sm text-slate-600">
+        Vérifiez les informations, ajustez vos notes et sauvegardez votre bonôme pour rejoindre l’aventure.
+      </p>
+    </div>
+
+    <BonomePreviewPanel />
+
+    <div class="grid gap-4 lg:grid-cols-2">
+      <section class="space-y-3 rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+        <header class="space-y-1">
+          <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Plan de matériel</h4>
+          <p class="text-xs text-slate-500">Anticipez la dotation initiale pour faciliter la prochaine session.</p>
+        </header>
+        <div class="space-y-2">
+          <div
+            v-for="entry in materialSummary"
+            :key="entry.id"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2"
+          >
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ entry.label }}</p>
+            <p class="mt-1 text-sm text-slate-700">{{ entry.value || 'À définir' }}</p>
+          </div>
+        </div>
+        <div class="rounded-lg border border-dashed border-slate-300 bg-white px-3 py-2 text-sm text-slate-600">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Notes complémentaires</p>
+          <p class="mt-1 whitespace-pre-line">{{ materialNotesDisplay || 'Aucune note particulière pour le moment.' }}</p>
+        </div>
+      </section>
+
+      <section class="space-y-3 rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+        <header class="space-y-1">
+          <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Portrait narratif</h4>
+          <p class="text-xs text-slate-500">Ces éléments nourriront le jeu de rôle et les interactions.</p>
+        </header>
+        <div class="space-y-2">
+          <div
+            v-for="entry in descriptionSummary"
+            :key="entry.id"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2"
+          >
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ entry.label }}</p>
+            <p class="mt-1 whitespace-pre-line text-sm text-slate-700">{{ entry.value || 'À préciser' }}</p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <div class="space-y-3">
+      <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Choix appliqués</h4>
+      <ul v-if="appliedChoices.length" class="space-y-2 text-sm text-slate-700">
+        <li v-for="choice in appliedChoices" :key="choice.id" class="rounded-lg border border-slate-200 bg-white px-3 py-2">
+          <span class="font-semibold">{{ choice.label }} :</span> {{ choice.displayValue }}
+        </li>
+      </ul>
+      <p v-else class="text-sm text-slate-500">Aucun choix complémentaire appliqué.</p>
+    </div>
+
+    <div class="flex flex-col gap-3 sm:flex-row sm:justify-end">
+      <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Revenir</button>
+      <button
+        type="button"
+        class="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700"
+        @click="emit('refresh')"
+      >
+        Rafraîchir la prévisualisation
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import BonomePreviewPanel from '@/components/BonomePreviewPanel.vue';
+import type { BonomePhaseMeta } from '@/components/bonomePhases';
+import {
+  DESCRIPTION_FIELD_DEFINITIONS,
+  MATERIAL_SLOT_DEFINITIONS,
+  useBonomeCreationStore
+} from '@/stores/bonomeCreation';
+
+const emit = defineEmits(['validate', 'cancel', 'refresh']);
+
+const props = defineProps<{
+  /**
+   * Métadonnées de l'étape de récapitulatif.
+   */
+  stepMeta: BonomePhaseMeta;
+  /**
+   * Aperçu calculé côté assistant, utilisé pour informer l'utilisateur sur l'état courant.
+   */
+  preview?: any | null;
+}>();
+
+const creation = useBonomeCreationStore();
+const { appliedChoices, preview: storePreview } = storeToRefs(creation);
+const materialPlan = creation.materialPlan;
+const descriptionFields = creation.descriptionFields;
+
+const equipmentSlots = MATERIAL_SLOT_DEFINITIONS;
+const descriptionFieldDefinitions = DESCRIPTION_FIELD_DEFINITIONS;
+
+const materialSummary = computed(() =>
+  equipmentSlots.map((slot) => ({
+    id: slot.id,
+    label: slot.label,
+    value: materialPlan[slot.id].trim()
+  }))
+);
+
+const descriptionSummary = computed(() =>
+  descriptionFieldDefinitions.map((field) => ({
+    id: field.id,
+    label: field.label,
+    value: descriptionFields[field.id].trim()
+  }))
+);
+
+const materialNotesDisplay = computed(() => materialPlan.notes.trim());
+
+const stepMeta = computed(() => props.stepMeta);
+
+// expose preview to template/users if needed
+const preview = computed(() => props.preview ?? storePreview.value ?? null);
+</script>

--- a/components/BonomeWizard.vue
+++ b/components/BonomeWizard.vue
@@ -37,636 +37,39 @@
       </nav>
     </header>
 
-    <!-- Identité -->
-    <section
-      v-if="isCurrentStep('identity')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <form class="grid gap-6 md:grid-cols-2" @submit.prevent>
-        <div class="space-y-4">
-          <div>
-            <label class="block text-sm font-medium text-slate-700">Prénom</label>
-            <input
-              v-model="characterFirstName"
-              type="text"
-              placeholder="Ex. Lina"
-              class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-            />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-slate-700">Nom</label>
-            <input
-              v-model="characterLastName"
-              type="text"
-              placeholder="Ex. Morcant"
-              class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-            />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-slate-700">Surnom</label>
-            <input
-              v-model="characterNickname"
-              type="text"
-              placeholder="Ex. L'Éclair"
-              class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-            />
-            <p class="mt-1 text-xs text-slate-500">Optionnel : sera affiché entre guillemets.</p>
-          </div>
-        </div>
-        <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
-          <p class="font-semibold text-slate-700">Aperçu rapide</p>
-          <dl class="mt-2 space-y-2">
-            <div>
-              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Nom complet</dt>
-              <dd class="text-sm text-slate-700">{{ fullNamePreview || '—' }}</dd>
-            </div>
-            <div>
-              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Nom affiché</dt>
-              <dd class="text-sm text-slate-700">{{ displayCharacterName }}</dd>
-            </div>
-            <div>
-              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Portrait généré</dt>
-              <dd class="text-sm text-slate-700">{{ displayCharacterName }}</dd>
-            </div>
-          </dl>
-        </div>
-      </form>
-
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Race -->
-    <section
-      v-else-if="isCurrentStep('race')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="space-y-2">
-        <h3 class="text-lg font-semibold text-slate-900">Choix de la race</h3>
-        <p class="text-sm text-slate-600">Sélectionnez la race correspondant à votre personnage.</p>
-      </div>
-      <div v-if="raceGroup" class="-mx-1 px-1">
-        <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
-          <CardArticleSpells
-            v-for="option in raceGroup.options"
-            :key="option.id"
-            :title="option.label"
-            :description="option.description"
-            :effact-label="option.effectLabel ?? undefined"
-            :image="option.image"
-            role="option"
-            :aria-selected="raceGroup.selected === option.id"
-            :selection-state="raceGroup.selected === option.id ? 'write' : 'none'"
-            :class="[
-              'snap-center focus-within:ring-2 focus-within:ring-blue-500',
-              raceGroup.selected === option.id
-                ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
-                : 'hover:border-slate-300 hover:shadow'
-            ]"
-            @write="selectPrimaryOption('race', option.id)"
-            @write-prepare="selectPrimaryOption('race', option.id)"
-            @reset="resetPrimarySelection('race', option.id)"
-          />
-        </div>
-      </div>
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Classe -->
-    <section
-      v-else-if="isCurrentStep('class')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="space-y-2">
-        <h3 class="text-lg font-semibold text-slate-900">Choix de la classe</h3>
-        <p class="text-sm text-slate-600">Sélectionnez la classe principale de votre bonôme.</p>
-      </div>
-      <div v-if="classGroup" class="-mx-1 px-1">
-        <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
-          <CardArticleSpells
-            v-for="option in classGroup.options"
-            :key="option.id"
-            :title="option.label"
-            :description="option.description"
-            :effact-label="option.effectLabel ?? undefined"
-            :image="option.image"
-            role="option"
-            :aria-selected="classGroup.selected === option.id"
-            :selection-state="classGroup.selected === option.id ? 'write' : 'none'"
-            :class="[
-              'snap-center focus-within:ring-2 focus-within:ring-blue-500',
-              classGroup.selected === option.id
-                ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
-                : 'hover:border-slate-300 hover:shadow'
-            ]"
-            @write="selectPrimaryOption('class', option.id)"
-            @write-prepare="selectPrimaryOption('class', option.id)"
-            @reset="resetPrimarySelection('class', option.id)"
-          />
-        </div>
-      </div>
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Niveau et caractéristiques -->
-    <section
-      v-else-if="isCurrentStep('level')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="grid gap-6 md:grid-cols-2">
-        <div>
-          <label class="block text-sm font-medium text-slate-700">Niveau</label>
-          <input
-            v-model.number="niveau"
-            type="number"
-            min="1"
-            max="3"
-            class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-          />
-          <p class="mt-1 text-xs text-slate-500">Le niveau est limité entre 1 et 3.</p>
-        </div>
-        <div class="space-y-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
-          <div>
-            <p class="font-semibold text-slate-700">Budget de points</p>
-            <p class="mt-1 text-xs text-slate-500">
-              Chaque caractéristique doit rester entre {{ pointBuyMin }} et {{ pointBuyMax }}.
-            </p>
-          </div>
-          <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Points restants</p>
-            <p :class="['text-base font-semibold', pointBuyStatusClass]">{{ pointBuyStatus.message }}</p>
-            <p class="text-xs text-slate-500">Coût total : {{ pointBuySpent }} / {{ pointBuyBudget }}</p>
-          </div>
-          <p class="text-xs text-slate-500">
-            Ajustez les caractéristiques en respectant votre budget de 27 points.
-          </p>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <div v-for="key in baseStatKeys" :key="key" class="space-y-3 rounded-lg border border-slate-200 p-4 shadow-sm">
-          <div class="flex items-center justify-between gap-3">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ key }}</p>
-              <p class="text-xs text-slate-400">Coût : {{ pointBuyCostFor(baseStats[key]) }} pts</p>
-            </div>
-            <div class="flex items-center gap-2">
-              <button
-                type="button"
-                class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 text-base font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
-                :aria-label="`Diminuer ${key}`"
-                :disabled="!canDecreaseStat(key)"
-                @click="handleDecreaseStat(key)"
-              >
-                −
-              </button>
-              <span class="w-10 text-center text-lg font-semibold text-slate-900">{{ baseStats[key] }}</span>
-              <button
-                type="button"
-                class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 text-base font-semibold text-slate-600 transition hover:border-blue-400 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
-                :aria-label="`Augmenter ${key}`"
-                :disabled="!canIncreaseStat(key)"
-                @click="handleIncreaseStat(key)"
-              >
-                +
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button
-          type="button"
-          class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white"
-          :class="!isPointBuyBalanced ? 'cursor-not-allowed opacity-60' : ''"
-          :disabled="!isPointBuyBalanced"
-          @click="handleValidate"
-        >
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Choix complémentaires -->
-    <section
-      v-else-if="isCurrentStep('choices')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="space-y-2">
-        <h3 class="text-lg font-semibold text-slate-900">Choix complémentaires</h3>
-        <p class="text-sm text-slate-600">Appliquez les options supplémentaires proposées par l'assistant.</p>
-      </div>
-
-      <section v-if="preview && preview.pendingChoices && preview.pendingChoices.length" class="space-y-4">
-        <article
-          v-for="(choice, idx) in preview.pendingChoices"
-          :key="getChoiceKey(choice, idx) ?? idx"
-          class="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
-        >
-          <header class="flex flex-col gap-2 border-b border-slate-100 pb-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h4 class="text-base font-semibold text-slate-900">{{ getChoiceTitle(choice) }}</h4>
-              <p class="text-xs text-slate-500">
-                Choisir {{ getChoiceRequirement(choice) }} / catégorie : {{ getChoiceCategoryLabel(choice) }}
-              </p>
-            </div>
-            <span class="text-xs font-medium uppercase tracking-wide text-slate-400">
-              Source : {{ getChoiceSourceLabel(choice) }}
-            </span>
-          </header>
-
-          <div class="space-y-4">
-            <div v-if="getChoiceOptions(choice).length" class="-mx-1 px-1">
-              <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
-                <CardArticleSpells
-                  v-for="(opt, optIdx) in getChoiceOptions(choice)"
-                  :key="typeof opt.value === 'object' ? optIdx : (opt.value ?? optIdx)"
-                  :title="opt.label"
-                  :description="getChoiceOptionDescription(opt)"
-                  :effact-label="opt.effectLabel ?? opt.effect_label ?? undefined"
-                  :image="getChoiceOptionImage(opt)"
-                  role="option"
-                  :aria-selected="isChoiceOptionSelected(choice, opt)"
-                  :selection-state="isChoiceOptionSelected(choice, opt) ? 'write' : 'none'"
-                  :class="[
-                    'snap-center focus-within:ring-2 focus-within:ring-blue-500',
-                    isChoiceOptionSelected(choice, opt)
-                      ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
-                      : 'hover:border-slate-300 hover:shadow',
-                    isChoiceOptionDisabled(choice, opt) ? 'cursor-not-allowed opacity-60' : ''
-                  ]"
-                  @write="handleChoiceOptionClick(choice, opt)"
-                  @write-prepare="handleChoiceOptionClick(choice, opt)"
-                  @reset="resetChoiceOption(choice, opt)"
-                />
-              </div>
-            </div>
-            <p v-else class="text-sm italic text-slate-500">
-              Aucune option lisible pour ce choix (vérifier la donnée).
-            </p>
-
-            <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
-              <span>
-                Sélection :
-                {{ getLocalChoiceCount(choice) }} / {{ getChoiceRequirement(choice) }}
-                <span v-if="getChoiceRequirement(choice) > 1">(sélection multiple autorisée)</span>
-              </span>
-              <div class="flex items-center gap-2">
-                <button
-                  type="button"
-                  class="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-semibold text-white"
-                  @click="applyChoice(choice)"
-                >
-                  Appliquer
-                </button>
-                <button
-                  type="button"
-                  class="rounded-lg border border-slate-200 px-3 py-1 text-xs"
-                  :disabled="!hasLocalChoiceValue(choice)"
-                  @click="resetChoice(choice)"
-                >
-                  Réinitialiser
-                </button>
-              </div>
-            </div>
-          </div>
-        </article>
-      </section>
-      <p v-else class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
-        Aucun choix complémentaire requis pour le moment.
-      </p>
-
-      <section v-if="appliedChoices.length" class="space-y-3">
-        <h4 class="text-sm font-semibold text-slate-700">Choix appliqués</h4>
-        <ul class="space-y-2">
-          <li
-            v-for="choice in appliedChoices"
-            :key="choice.id"
-            class="flex items-start justify-between gap-4 rounded-lg border border-slate-200 bg-white p-3 text-sm shadow-sm"
-          >
-            <div>
-              <p class="font-semibold text-slate-800">{{ choice.label }}</p>
-              <p class="text-xs text-slate-500">{{ choice.displayValue }}</p>
-            </div>
-            <button
-              type="button"
-              class="rounded-lg border border-slate-200 px-3 py-1 text-xs"
-              @click="resetChoiceById(choice.id)"
-            >
-              Retirer
-            </button>
-          </li>
-        </ul>
-      </section>
-
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Matériel -->
-    <section
-      v-else-if="isCurrentStep('equipment')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="space-y-2">
-        <h3 class="text-lg font-semibold text-slate-900">Matériel</h3>
-        <p class="text-sm text-slate-600">
-          Réservez les emplacements clés de l’équipement : chaque bloc sera enrichi par la suite par
-          l’assistant ou vos choix manuels.
-        </p>
-      </div>
-      <div class="grid gap-4 md:grid-cols-2">
-        <article
-          v-for="slot in equipmentSlots"
-          :key="slot.id"
-          class="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
-        >
-          <header class="flex items-start justify-between gap-3">
-            <div>
-              <h4 class="text-sm font-semibold text-slate-900">{{ slot.label }}</h4>
-              <p class="text-xs text-slate-500">{{ slot.hint }}</p>
-            </div>
-            <button
-              type="button"
-              class="cursor-not-allowed rounded-full border border-dashed border-slate-300 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-slate-400"
-              disabled
-            >
-              À venir
-            </button>
-          </header>
-          <input
-            v-model="materialPlan[slot.id]"
-            type="text"
-            :placeholder="slot.placeholder"
-            class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-          />
-        </article>
-      </div>
-      <div>
-        <label class="block text-sm font-medium text-slate-700">Notes complémentaires</label>
-        <textarea
-          v-model="materialPlan.notes"
-          rows="4"
-          class="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-          placeholder="Consignez les ajustements libres : munitions, potions, objets uniques…"
-        ></textarea>
-        <p class="mt-1 text-xs text-slate-500">
-          Ces informations seront ajoutées à la fiche finale du personnage.
-        </p>
-      </div>
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Description -->
-    <section
-      v-else-if="isCurrentStep('description')"
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="space-y-2">
-        <h3 class="text-lg font-semibold text-slate-900">Description narrative</h3>
-        <p class="text-sm text-slate-600">
-          Renseignez les repères narratifs clés : ces éléments complètent la fiche pour donner vie au personnage.
-        </p>
-      </div>
-      <div class="grid gap-4 md:grid-cols-2">
-        <article
-          v-for="field in descriptionFieldDefinitions"
-          :key="field.id"
-          class="space-y-2 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
-        >
-          <div>
-            <label class="block text-sm font-semibold text-slate-800">{{ field.label }}</label>
-            <p v-if="field.hint" class="mt-1 text-xs text-slate-500">{{ field.hint }}</p>
-          </div>
-          <textarea
-            v-model="descriptionFields[field.id]"
-            rows="4"
-            class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-            :placeholder="field.placeholder"
-          ></textarea>
-        </article>
-      </div>
-      <div class="flex justify-end gap-3">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Annuler</button>
-        <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="handleValidate">
-          Valider
-        </button>
-      </div>
-    </section>
-
-    <!-- Récapitulatif -->
-    <section
-      v-else
-      class="space-y-6 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm"
-    >
-      <div class="space-y-3">
-        <h3 class="text-lg font-semibold text-slate-900">Récapitulatif</h3>
-        <p class="text-sm text-slate-600">
-          Vérifiez les informations, ajustez vos notes et sauvegardez votre bonôme pour rejoindre l’aventure.
-        </p>
-      </div>
-
-      <BonomePreviewPanel />
-
-      <div class="grid gap-4 lg:grid-cols-2">
-        <section class="space-y-3 rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
-          <header class="space-y-1">
-            <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Plan de matériel</h4>
-            <p class="text-xs text-slate-500">Anticipez la dotation initiale pour faciliter la prochaine session.</p>
-          </header>
-          <div class="space-y-2">
-            <div
-              v-for="entry in materialSummary"
-              :key="entry.id"
-              class="rounded-lg border border-slate-200 bg-white px-3 py-2"
-            >
-              <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ entry.label }}</p>
-              <p class="mt-1 text-sm text-slate-700">{{ entry.value || 'À définir' }}</p>
-            </div>
-          </div>
-          <div class="rounded-lg border border-dashed border-slate-300 bg-white px-3 py-2 text-sm text-slate-600">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Notes complémentaires</p>
-            <p class="mt-1 whitespace-pre-line">{{ materialNotesDisplay || 'Aucune note particulière pour le moment.' }}</p>
-          </div>
-        </section>
-
-        <section class="space-y-3 rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
-          <header class="space-y-1">
-            <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Portrait narratif</h4>
-            <p class="text-xs text-slate-500">Ces éléments nourriront le jeu de rôle et les interactions.</p>
-          </header>
-          <div class="space-y-2">
-            <div
-              v-for="entry in descriptionSummary"
-              :key="entry.id"
-              class="rounded-lg border border-slate-200 bg-white px-3 py-2"
-            >
-              <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ entry.label }}</p>
-              <p class="mt-1 whitespace-pre-line text-sm text-slate-700">{{ entry.value || 'À préciser' }}</p>
-            </div>
-          </div>
-        </section>
-      </div>
-
-      <div class="space-y-3">
-        <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Choix appliqués</h4>
-        <ul v-if="appliedChoices.length" class="space-y-2 text-sm text-slate-700">
-          <li v-for="choice in appliedChoices" :key="choice.id" class="rounded-lg border border-slate-200 bg-white px-3 py-2">
-            <span class="font-semibold">{{ choice.label }} :</span> {{ choice.displayValue }}
-          </li>
-        </ul>
-        <p v-else class="text-sm text-slate-500">Aucun choix complémentaire appliqué.</p>
-      </div>
-
-      <div class="flex flex-col gap-3 sm:flex-row sm:justify-end">
-        <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="handleCancel">Revenir</button>
-        <button
-          type="button"
-          class="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700"
-          @click="refreshPreview"
-        >
-          Rafraîchir la prévisualisation
-        </button>
-      </div>
-    </section>
+    <component
+      :is="activePhase.component"
+      v-bind="phaseProps"
+      @validate="handleValidate"
+      @cancel="handleCancel"
+      @refresh="handleRefresh"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, defineAsyncComponent, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import CardArticleSpells from '~/components/CardArticleSpells.vue';
-import BonomePreviewPanel from '~/components/BonomePreviewPanel.vue';
+import type { BonomePhaseComponentConfig, BonomePhaseMeta, BonomePhaseProps } from '@/components/bonomePhases';
 import {
   DESCRIPTION_FIELD_DEFINITIONS,
   MATERIAL_SLOT_DEFINITIONS,
-  useBonomeCreationStore,
-  type DescriptionFields,
-  type MaterialPlan
-} from '~/stores/bonomeCreation';
-
-type StepId =
-  | 'identity'
-  | 'race'
-  | 'class'
-  | 'level'
-  | 'choices'
-  | 'equipment'
-  | 'description'
-  | 'recap';
-
-type StepDefinition = {
-  id: StepId;
-  title: string;
-  shortTitle: string;
-  description?: string;
-  onValidate?: () => Promise<void> | void;
-  onReset?: () => Promise<void> | void;
-};
+  useBonomeCreationStore
+} from '@/stores/bonomeCreation';
 
 const creation = useBonomeCreationStore();
 
 const {
   primarySelectionGroups,
-  niveau,
   preview,
-  appliedChoices,
   selectedClass,
   selectedRace,
-  selectedBackground,
   characterFirstName,
   characterLastName,
   characterNickname,
-  fullCharacterName,
-  displayCharacterName,
-  pointBuyBudget,
-  pointBuyRemaining,
-  pointBuySpent,
-  isPointBuyBalanced,
-  pointBuyMin,
-  pointBuyMax
+  niveau
 } = storeToRefs(creation);
-
-const fullNamePreview = computed(() => fullCharacterName.value.trim());
-
-const baseStats = creation.baseStats;
-const { pointBuyCostFor } = creation;
-const materialPlan = creation.materialPlan as MaterialPlan;
-const descriptionFields = creation.descriptionFields as DescriptionFields;
-const currentStep = ref<number>(0);
-
-type BaseStatKey = keyof typeof baseStats;
-
-const baseStatKeys = computed(() => Object.keys(baseStats) as BaseStatKey[]);
-
-const equipmentSlots = MATERIAL_SLOT_DEFINITIONS;
-const descriptionFieldDefinitions = DESCRIPTION_FIELD_DEFINITIONS;
-
-const materialSummary = computed(() =>
-  equipmentSlots.map((slot) => ({
-    id: slot.id,
-    label: slot.label,
-    value: materialPlan[slot.id].trim()
-  }))
-);
-
-const descriptionSummary = computed(() =>
-  descriptionFieldDefinitions.map((field) => ({
-    id: field.id,
-    label: field.label,
-    value: descriptionFields[field.id].trim()
-  }))
-);
-
-const materialNotesDisplay = computed(() => materialPlan.notes.trim());
-
-const pointBuyStatus = computed(() => {
-  const remaining = pointBuyRemaining.value;
-  if (remaining < 0) {
-    return { message: `Budget dépassé de ${Math.abs(remaining)} pts`, tone: 'error' as const };
-  }
-  if (remaining > 0) {
-    return { message: `${remaining} pts à répartir`, tone: 'warn' as const };
-  }
-  return { message: 'Budget équilibré', tone: 'ok' as const };
-});
-
-const pointBuyStatusClass = computed(() => {
-  switch (pointBuyStatus.value.tone) {
-    case 'error':
-      return 'text-red-600';
-    case 'warn':
-      return 'text-amber-600';
-    default:
-      return 'text-emerald-600';
-  }
-});
 
 const refreshPreview = async () => {
   await creation.sendPreview();
@@ -695,18 +98,6 @@ const resetLevelAndStats = async () => {
   await refreshPreview();
 };
 
-const handleIncreaseStat = (key: BaseStatKey) => {
-  creation.increaseBaseStat(key);
-};
-
-const handleDecreaseStat = (key: BaseStatKey) => {
-  creation.decreaseBaseStat(key);
-};
-
-const canIncreaseStat = (key: BaseStatKey) => creation.canIncreaseBaseStat(key);
-
-const canDecreaseStat = (key: BaseStatKey) => creation.canDecreaseBaseStat(key);
-
 const resetComplementaryChoices = async () => {
   const keys = Object.keys(creation.chosenOptions);
   await Promise.all(keys.map((key) => creation.resetChoiceById(key)));
@@ -723,19 +114,19 @@ const resetComplementaryChoices = async () => {
 };
 
 const resetEquipment = () => {
-  equipmentSlots.forEach(({ id }) => {
-    materialPlan[id] = '';
+  MATERIAL_SLOT_DEFINITIONS.forEach(({ id }) => {
+    creation.materialPlan[id] = '';
   });
-  materialPlan.notes = '';
+  creation.materialPlan.notes = '';
 };
 
 const resetDescription = () => {
-  descriptionFieldDefinitions.forEach(({ id }) => {
-    descriptionFields[id] = '';
+  DESCRIPTION_FIELD_DEFINITIONS.forEach(({ id }) => {
+    creation.descriptionFields[id] = '';
   });
 };
 
-const steps: StepDefinition[] = [
+const steps: BonomePhaseMeta[] = [
   {
     id: 'identity',
     title: 'Identité du personnage',
@@ -799,12 +190,40 @@ const steps: StepDefinition[] = [
   }
 ];
 
+const phases: BonomePhaseComponentConfig[] = [
+  { id: 'identity', component: defineAsyncComponent(() => import('@/components/BonomePhase1.vue')) },
+  { id: 'race', component: defineAsyncComponent(() => import('@/components/BonomePhase2.vue')) },
+  { id: 'class', component: defineAsyncComponent(() => import('@/components/BonomePhase3.vue')) },
+  { id: 'level', component: defineAsyncComponent(() => import('@/components/BonomePhase4.vue')) },
+  { id: 'choices', component: defineAsyncComponent(() => import('@/components/BonomePhase5.vue')) },
+  { id: 'equipment', component: defineAsyncComponent(() => import('@/components/BonomePhase6.vue')) },
+  { id: 'description', component: defineAsyncComponent(() => import('@/components/BonomePhase7.vue')) },
+  { id: 'recap', component: defineAsyncComponent(() => import('@/components/BonomePhase8.vue')) }
+];
+
+const currentStep = ref(0);
+
 const activeStep = computed(() => steps[currentStep.value] ?? steps[0]);
+const activePhase = computed(() => phases.find((phase) => phase.id === activeStep.value.id) ?? phases[0]);
 
 const raceGroup = computed(() => primarySelectionGroups.value.find((group) => group.id === 'race') ?? null);
 const classGroup = computed(() => primarySelectionGroups.value.find((group) => group.id === 'class') ?? null);
 
-const isCurrentStep = (id: StepId) => activeStep.value.id === id;
+const phaseProps = computed<BonomePhaseProps>(() => {
+  const base: BonomePhaseProps = { stepMeta: activeStep.value };
+  switch (activeStep.value.id) {
+    case 'race':
+      return { ...base, raceGroup: raceGroup.value };
+    case 'class':
+      return { ...base, classGroup: classGroup.value };
+    case 'choices':
+      return { ...base, preview: preview.value };
+    case 'recap':
+      return { ...base, preview: preview.value };
+    default:
+      return base;
+  }
+});
 
 const goToStep = (index: number) => {
   if (index < 0) {
@@ -838,47 +257,8 @@ const handleCancel = async () => {
   }
 };
 
-const {
-  getChoiceKey,
-  getChoiceTitle,
-  getChoiceRequirement,
-  getChoiceCategoryLabel,
-  getChoiceSourceLabel,
-  getChoiceOptions,
-  getChoiceOptionDescription,
-  getChoiceOptionImage,
-  isChoiceOptionDisabled,
-  handleChoiceOptionClick,
-  isChoiceOptionSelected,
-  getLocalChoiceCount,
-  applyChoice,
-  getPrimarySelectedLabel,
-  resetChoice,
-  hasLocalChoiceValue,
-  resetChoiceById,
-  selectPrimaryOption
-} = creation;
-
-const resetPrimarySelection = (
-  groupId: 'class' | 'race' | 'background',
-  optionId: string
-) => {
-  const map = {
-    class: selectedClass,
-    race: selectedRace,
-    background: selectedBackground
-  } as const;
-  const target = map[groupId];
-  if (!target) return;
-  if (target.value === optionId) {
-    target.value = '';
-  }
-};
-
-const resetChoiceOption = (choice: any, option: any) => {
-  if (isChoiceOptionSelected(choice, option)) {
-    handleChoiceOptionClick(choice, option);
-  }
+const handleRefresh = async () => {
+  await refreshPreview();
 };
 
 onMounted(() => {

--- a/components/bonomePhases.ts
+++ b/components/bonomePhases.ts
@@ -1,0 +1,34 @@
+import type { DefineComponent } from 'vue';
+
+import type { PrimarySelectionGroup } from '@/stores/bonomeCreation';
+
+export type BonomePhaseId =
+  | 'identity'
+  | 'race'
+  | 'class'
+  | 'level'
+  | 'choices'
+  | 'equipment'
+  | 'description'
+  | 'recap';
+
+export type BonomePhaseMeta = {
+  id: BonomePhaseId;
+  title: string;
+  shortTitle: string;
+  description?: string;
+  onValidate?: () => Promise<void> | void;
+  onReset?: () => Promise<void> | void;
+};
+
+export type BonomePhaseComponentConfig = {
+  id: BonomePhaseId;
+  component: DefineComponent;
+};
+
+export type BonomePhaseProps = {
+  stepMeta: BonomePhaseMeta;
+  raceGroup?: PrimarySelectionGroup | null;
+  classGroup?: PrimarySelectionGroup | null;
+  preview?: any | null;
+};


### PR DESCRIPTION
## Summary
- split the bonôme creation steps into dedicated `BonomePhase1-8` components that encapsulate their templates and store bindings
- introduce shared phase typing and rework `BonomeWizard` to asynchronously load phases and relay validate/cancel/refresh events
- keep preview orchestration intact while wiring resets and refresh through the new event system

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbdbb921f8832abbd5710b75e39f63