### PR TITLE
Handle empty catalogs in bonome creation

### DIFF
--- a/components/BonomePhase2.vue
+++ b/components/BonomePhase2.vue
@@ -4,8 +4,11 @@
       <h3 class="text-lg font-semibold text-slate-900">Choix de la race</h3>
       <p class="text-sm text-slate-600">Sélectionnez la race correspondant à votre personnage.</p>
     </div>
-    <div v-if="raceGroup" class="-mx-1 px-1">
-      <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+    <div v-if="raceGroup" class="-mx-1 space-y-4 px-1">
+      <div
+        v-if="raceGroup.options.length"
+        class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+      >
         <CardArticleSpells
           v-for="option in raceGroup.options"
           :key="option.id"
@@ -25,10 +28,25 @@
           @reset="resetPrimarySelection(option.id)"
         />
       </div>
+      <p v-else class="rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-600">
+        Aucune option de race n’est disponible pour le moment. Veuillez réessayer plus tard ou actualiser le catalogue.
+      </p>
     </div>
+    <p
+      v-else
+      class="rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-600"
+    >
+      Les données de catalogue ne sont pas encore chargées. Patientez un instant ou réessayez.
+    </p>
     <div class="flex justify-end gap-3">
       <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
-      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+      <button
+        type="button"
+        class="rounded-lg px-4 py-2 text-sm font-semibold text-white"
+        :class="canValidate ? 'bg-blue-600 hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500' : 'bg-slate-300 text-slate-500 cursor-not-allowed'"
+        :disabled="!canValidate"
+        @click="emit('validate')"
+      >
         Valider
       </button>
     </div>
@@ -69,4 +87,5 @@ const resetPrimarySelection = (optionId: string) => {
 
 const stepMeta = computed(() => props.stepMeta);
 const raceGroup = computed(() => props.raceGroup);
+const canValidate = computed(() => Boolean(raceGroup.value?.options.length));
 </script>

--- a/components/BonomePhase3.vue
+++ b/components/BonomePhase3.vue
@@ -4,8 +4,11 @@
       <h3 class="text-lg font-semibold text-slate-900">Choix de la classe</h3>
       <p class="text-sm text-slate-600">Sélectionnez la classe principale de votre bonôme.</p>
     </div>
-    <div v-if="classGroup" class="-mx-1 px-1">
-      <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+    <div v-if="classGroup" class="-mx-1 space-y-4 px-1">
+      <div
+        v-if="classGroup.options.length"
+        class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+      >
         <CardArticleSpells
           v-for="option in classGroup.options"
           :key="option.id"
@@ -27,10 +30,25 @@
           @reset="resetPrimarySelection(option.id)"
         />
       </div>
+      <p v-else class="rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-600">
+        Aucune classe n’est disponible pour le moment. Veuillez réessayer plus tard ou actualiser le catalogue.
+      </p>
     </div>
+    <p
+      v-else
+      class="rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-600"
+    >
+      Les données de catalogue ne sont pas encore chargées. Patientez un instant ou réessayez.
+    </p>
     <div class="flex justify-end gap-3">
       <button type="button" class="rounded-lg border border-slate-200 px-4 py-2 text-sm" @click="emit('cancel')">Annuler</button>
-      <button type="button" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white" @click="emit('validate')">
+      <button
+        type="button"
+        class="rounded-lg px-4 py-2 text-sm font-semibold text-white"
+        :class="canValidate ? 'bg-blue-600 hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500' : 'bg-slate-300 text-slate-500 cursor-not-allowed'"
+        :disabled="!canValidate"
+        @click="emit('validate')"
+      >
         Valider
       </button>
     </div>
@@ -71,4 +89,5 @@ const resetPrimarySelection = (optionId: string) => {
 
 const stepMeta = computed(() => props.stepMeta);
 const classGroup = computed(() => props.classGroup);
+const canValidate = computed(() => Boolean(classGroup.value?.options.length));
 </script>

--- a/stores/bonomeCreation.ts
+++ b/stores/bonomeCreation.ts
@@ -257,40 +257,6 @@ const normalizeCatalogEntries = (payload: unknown): CatalogEntry[] => {
   return Array.from(entries.values());
 };
 
-const fallbackCatalogEntries = (entries: Array<string | Partial<CatalogEntry>>): CatalogEntry[] =>
-  entries
-    .map((entry, index) => {
-      if (typeof entry === 'string') {
-        const id = normalizeId(entry);
-        if (!id) return null;
-        return {
-          id,
-          name: humanizeLabel(id),
-          description: null,
-          image: null
-        } satisfies CatalogEntry;
-      }
-
-      if (entry && typeof entry === 'object') {
-        const id = normalizeId(entry.id ?? entry.name ?? `fallback_${index}`);
-        if (!id) return null;
-
-        const name = typeof entry.name === 'string' && entry.name.trim().length ? entry.name.trim() : humanizeLabel(id);
-        const description = typeof entry.description === 'string' && entry.description.trim().length ? entry.description.trim() : null;
-        const image = typeof entry.image === 'string' && entry.image.trim().length ? entry.image.trim() : null;
-
-        return {
-          id,
-          name,
-          description,
-          image
-        } satisfies CatalogEntry;
-      }
-
-      return null;
-    })
-    .filter((entry): entry is CatalogEntry => Boolean(entry));
-
 const extractChoiceFrom = (choice: any): any[] => {
   if (Array.isArray(choice?.from) && choice.from.length) {
     return choice.from;
@@ -1043,135 +1009,40 @@ export const useBonomeCreationStore = defineStore('bonomeCreation', () => {
   );
 
   const loadCatalog = async () => {
-    const assignCatalog = (
-      target: { value: CatalogEntry[] },
-      payload: unknown,
-      fallbackEntries: Array<string | Partial<CatalogEntry>>
-    ) => {
-      const normalized = normalizeCatalogEntries(payload);
-      target.value = normalized.length ? normalized : fallbackCatalogEntries(fallbackEntries);
+    const assignCatalog = (target: { value: CatalogEntry[] }, payload: unknown) => {
+      target.value = normalizeCatalogEntries(payload);
     };
 
-    try {
-      const response = await requestFetch('/api/catalog/classes').catch(() => null);
-      assignCatalog(classes, response, [
-        {
-          id: 'mage',
-          name: 'Mage',
-          description: 'Maîtres des arcanes, les mages manipulent les énergies mystiques pour façonner la réalité.'
-        },
-        {
-          id: 'guerrier',
-          name: 'Guerrier',
-          description: 'Combattants polyvalents et endurcis, les guerriers excellent sur tous les champs de bataille.'
-        },
-        {
-          id: 'rodeur',
-          name: 'Rôdeur',
-          description: 'Silencieux et précis, les rôdeurs allient talents de pisteur et maîtrise martiale.'
-        }
-      ]);
-    } catch (error) {
-      classes.value = fallbackCatalogEntries([
-        {
-          id: 'mage',
-          name: 'Mage',
-          description: 'Maîtres des arcanes, les mages manipulent les énergies mystiques pour façonner la réalité.'
-        },
-        {
-          id: 'guerrier',
-          name: 'Guerrier',
-          description: 'Combattants polyvalents et endurcis, les guerriers excellent sur tous les champs de bataille.'
-        },
-        {
-          id: 'rodeur',
-          name: 'Rôdeur',
-          description: 'Silencieux et précis, les rôdeurs allient talents de pisteur et maîtrise martiale.'
-        }
-      ]);
-    }
+    const ensureSelectionValidity = (
+      selected: { value: string },
+      entries: CatalogEntry[]
+    ) => {
+      if (!entries.length) {
+        selected.value = '';
+        return;
+      }
+      const hasSelection = entries.some((entry) => entry.id === selected.value);
+      if (!selected.value) {
+        selected.value = entries[0].id;
+        return;
+      }
+      if (!hasSelection) {
+        selected.value = '';
+      }
+    };
 
-    try {
-      const response = await requestFetch('/api/catalog/races').catch(() => null);
-      assignCatalog(races, response, [
-        {
-          id: 'humain',
-          name: 'Humain',
-          description: 'Adaptables et ambitieux, les humains se retrouvent dans toutes les régions du monde.'
-        },
-        {
-          id: 'elfe',
-          name: 'Elfe',
-          description: 'Gracieux et proches de la nature, les elfes vivent selon des traditions millénaires.'
-        },
-        {
-          id: 'nain',
-          name: 'Nain',
-          description: 'Forgerons et bâtisseurs inégalés, les nains valorisent honneur et artisanat.'
-        }
-      ]);
-    } catch (error) {
-      races.value = fallbackCatalogEntries([
-        {
-          id: 'humain',
-          name: 'Humain',
-          description: 'Adaptables et ambitieux, les humains se retrouvent dans toutes les régions du monde.'
-        },
-        {
-          id: 'elfe',
-          name: 'Elfe',
-          description: 'Gracieux et proches de la nature, les elfes vivent selon des traditions millénaires.'
-        },
-        {
-          id: 'nain',
-          name: 'Nain',
-          description: 'Forgerons et bâtisseurs inégalés, les nains valorisent honneur et artisanat.'
-        }
-      ]);
-    }
+    const classResponse = await requestFetch('/api/catalog/classes').catch(() => null);
+    assignCatalog(classes, classResponse);
 
-    try {
-      const response = await requestFetch('/api/catalog/backgrounds').catch(() => null);
-      assignCatalog(backgrounds, response, [
-        {
-          id: 'acolyte',
-          name: 'Acolyte',
-          description: 'Élevé dans un temple, l’acolyte porte les traditions sacrées et la sagesse de sa foi.'
-        },
-        {
-          id: 'aventurier',
-          name: 'Aventurier',
-          description: 'Toujours en quête de découvertes, l’aventurier parcourt le monde en quête de gloire.'
-        },
-        {
-          id: 'erudit',
-          name: 'Érudit',
-          description: 'Passionné par le savoir, l’érudit a passé des années plongé dans les livres et les archives.'
-        }
-      ]);
-    } catch (error) {
-      backgrounds.value = fallbackCatalogEntries([
-        {
-          id: 'acolyte',
-          name: 'Acolyte',
-          description: 'Élevé dans un temple, l’acolyte porte les traditions sacrées et la sagesse de sa foi.'
-        },
-        {
-          id: 'aventurier',
-          name: 'Aventurier',
-          description: 'Toujours en quête de découvertes, l’aventurier parcourt le monde en quête de gloire.'
-        },
-        {
-          id: 'erudit',
-          name: 'Érudit',
-          description: 'Passionné par le savoir, l’érudit a passé des années plongé dans les livres et les archives.'
-        }
-      ]);
-    }
+    const raceResponse = await requestFetch('/api/catalog/races').catch(() => null);
+    assignCatalog(races, raceResponse);
 
-    if (!selectedClass.value && classes.value.length) selectedClass.value = classes.value[0].id;
-    if (!selectedRace.value && races.value.length) selectedRace.value = races.value[0].id;
-    if (!selectedBackground.value && backgrounds.value.length) selectedBackground.value = backgrounds.value[0].id;
+    const backgroundResponse = await requestFetch('/api/catalog/backgrounds').catch(() => null);
+    assignCatalog(backgrounds, backgroundResponse);
+
+    ensureSelectionValidity(selectedClass, classes.value);
+    ensureSelectionValidity(selectedRace, races.value);
+    ensureSelectionValidity(selectedBackground, backgrounds.value);
   };
 
   const sendPreview = async () => {

--- a/tests/bonomeCreationStore.test.ts
+++ b/tests/bonomeCreationStore.test.ts
@@ -53,8 +53,22 @@ const unwrap = <T>(maybeRef: T | { value: T }): T => {
 
 const serializeReactive = (value: any) => JSON.parse(JSON.stringify(value));
 
-const createFetchStub = (log: Array<{ url: string; options?: any }>): FetchHandler => {
-  const catalogResponses: Record<string, any> = {
+type FetchStubOverride =
+  | any
+  | Error
+  | (() => any)
+  | (() => Promise<any>);
+
+type FetchStubOptions = {
+  catalog?: Partial<Record<string, FetchStubOverride>>;
+  preview?: FetchStubOverride;
+};
+
+const createFetchStub = (
+  log: Array<{ url: string; options?: any }>,
+  options: FetchStubOptions = {}
+): FetchHandler => {
+  const catalogResponses: Record<string, FetchStubOverride> = {
     '/api/catalog/classes': [
       { id: 'wizard', name: 'Mage' },
       { id: 'ranger', name: 'Rôdeur' }
@@ -65,10 +79,11 @@ const createFetchStub = (log: Array<{ url: string; options?: any }>): FetchHandl
     ],
     '/api/catalog/backgrounds': [
       { id: 'sage', name: 'Sage' }
-    ]
+    ],
+    ...(options.catalog ?? {})
   };
 
-  const previewResponse = {
+  const previewResponse: FetchStubOverride = options.preview ?? {
     ok: true,
     pendingChoices: [],
     previewCharacter: {
@@ -81,9 +96,22 @@ const createFetchStub = (log: Array<{ url: string; options?: any }>): FetchHandl
   return async (url: string, options?: any) => {
     log.push({ url, options });
     if (url in catalogResponses) {
-      return catalogResponses[url];
+      const response = catalogResponses[url];
+      if (typeof response === 'function') {
+        return await response();
+      }
+      if (response instanceof Error) {
+        throw response;
+      }
+      return response;
     }
     if (url === '/api/creation/preview') {
+      if (typeof previewResponse === 'function') {
+        return await previewResponse();
+      }
+      if (previewResponse instanceof Error) {
+        throw previewResponse;
+      }
       return previewResponse;
     }
     throw new Error(`Unhandled fetch to ${url}`);
@@ -267,6 +295,21 @@ export async function run() {
         unwrap(reloadedStore.backgrounds).length > 0,
       'reloaded store should populate catalog entries'
     );
+    assert.deepEqual(
+      unwrap(reloadedStore.classes).map((entry) => entry.id),
+      ['wizard', 'ranger'],
+      'reloaded store should use API-provided classes'
+    );
+    assert.deepEqual(
+      unwrap(reloadedStore.races).map((entry) => entry.id),
+      ['elf', 'human'],
+      'reloaded store should use API-provided races'
+    );
+    assert.deepEqual(
+      unwrap(reloadedStore.backgrounds).map((entry) => entry.id),
+      ['sage'],
+      'reloaded store should use API-provided backgrounds'
+    );
 
     const previewCall = fetchLog.find((call) => call.url === '/api/creation/preview');
     assert.ok(previewCall, 'preview call should be logged after reload');
@@ -289,6 +332,64 @@ export async function run() {
       previewCall?.options?.body?.baseCharacter?.name,
       'Aldara Sombrelune « La Ruse »',
       'preview should include combined full name'
+    );
+
+    fetchLog.length = 0;
+    __setNuxtAppStub({
+      $fetch: createFetchStub(fetchLog, {
+        catalog: {
+          '/api/catalog/classes': [],
+          '/api/catalog/races': [],
+          '/api/catalog/backgrounds': []
+        }
+      })
+    });
+    (process as any).client = false;
+    (globalThis as any).localStorage = createLocalStorageMock();
+    setActivePinia(createPinia());
+    const emptyCatalogStore = useBonomeCreationStore();
+
+    await emptyCatalogStore.initialize();
+
+    assert.deepEqual(
+      unwrap(emptyCatalogStore.classes),
+      [],
+      'store should keep classes empty when API returns no data'
+    );
+    assert.deepEqual(
+      unwrap(emptyCatalogStore.races),
+      [],
+      'store should keep races empty when API returns no data'
+    );
+    assert.deepEqual(
+      unwrap(emptyCatalogStore.backgrounds),
+      [],
+      'store should keep backgrounds empty when API returns no data'
+    );
+    assert.equal(
+      unwrap(emptyCatalogStore.selectedClass),
+      '',
+      'class selection should reset when no options are available'
+    );
+    assert.equal(
+      unwrap(emptyCatalogStore.selectedRace),
+      '',
+      'race selection should reset when no options are available'
+    );
+    assert.equal(
+      unwrap(emptyCatalogStore.selectedBackground),
+      '',
+      'background selection should reset when no options are available'
+    );
+    assert.equal(
+      fetchLog.filter((call) => call.url.startsWith('/api/catalog/')).length,
+      3,
+      'empty catalog initialization should still call each catalog endpoint once'
+    );
+    assert.equal(
+      fetchLog.filter((call) => call.url === '/api/creation/preview').length,
+      1,
+      'empty catalog initialization should still trigger a preview request'
     );
   } finally {
     if (originalProcessClient === undefined) {


### PR DESCRIPTION
## Summary
- stop using hard-coded fallback catalog entries in the bonôme creation store and reset invalid selections
- show empty-state messaging and disable validation in race/class phases when no options are available
- extend the bonôme creation store tests to cover empty catalog scenarios and configurable fetch stubs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dbe1cef764832a8ffdb6cee85d4c4c