### PR TITLE
Use Nuxt request fetch in bonome creation store

### DIFF
--- a/stores/bonomeCreation.ts
+++ b/stores/bonomeCreation.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, ref, watch } from 'vue';
-import { useNuxtApp } from '#app';
+import { useRequestFetch } from '#app';
 
 import type { Personnage } from './personnage';
 
@@ -384,11 +384,6 @@ const formatChoiceValue = (key: string, value: any, options: ChoiceOption[]): st
   }
 
   return toLabel(value);
-};
-
-const useRequestFetch = () => {
-  const nuxtApp = useNuxtApp();
-  return nuxtApp.$fetch;
 };
 
 export const useBonomeCreationStore = defineStore('bonomeCreation', () => {


### PR DESCRIPTION
## Summary
- replace the custom useRequestFetch helper with Nuxt's implementation in the bonome creation store
- keep the store's requestFetch usage so catalog loading and preview submission continue working with the request-scoped fetch

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe7b7ea7c832a90a2e3d9d2f1861e