### PR TITLE
Refactor Bonome selection grids

### DIFF
--- a/components/BonomePhase2.vue
+++ b/components/BonomePhase2.vue
@@ -4,10 +4,10 @@
       <h3 class="text-lg font-semibold text-slate-900">Choix de la race</h3>
       <p class="text-sm text-slate-600">Sélectionnez la race correspondant à votre personnage.</p>
     </div>
-    <div v-if="raceGroup" class="-mx-1 space-y-4 px-1">
+    <div v-if="raceGroup" class="space-y-4">
       <div
         v-if="raceGroup.options.length"
-        class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+        class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4"
       >
         <CardArticle
           v-for="option in raceGroup.options"
@@ -18,8 +18,10 @@
           role="option"
           :aria-selected="raceGroup.selected === option.id"
           :class="[
-            'snap-center focus-within:ring-2 focus-within:ring-blue-500',
-            raceGroup.selected === option.id ? 'ring-2 ring-blue-500 border-blue-500 shadow-md' : 'hover:border-slate-300 hover:shadow'
+            'h-full w-full max-w-none focus-within:ring-2 focus-within:ring-blue-500',
+            raceGroup.selected === option.id
+              ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
+              : 'hover:border-slate-300 hover:shadow'
           ]"
           :selected="raceGroup.selected === option.id"
           @select="handleRaceSelection(option.id, $event)"

--- a/components/BonomePhase3.vue
+++ b/components/BonomePhase3.vue
@@ -4,10 +4,10 @@
       <h3 class="text-lg font-semibold text-slate-900">Choix de la classe</h3>
       <p class="text-sm text-slate-600">Sélectionnez la classe principale de votre bonôme.</p>
     </div>
-    <div v-if="classGroup" class="-mx-1 space-y-4 px-1">
+    <div v-if="classGroup" class="space-y-4">
       <div
         v-if="classGroup.options.length"
-        class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+        class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4"
       >
         <CardArticle
           v-for="option in classGroup.options"
@@ -18,7 +18,7 @@
           role="option"
           :aria-selected="classGroup.selected === option.id"
           :class="[
-            'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+            'h-full w-full max-w-none focus-within:ring-2 focus-within:ring-blue-500',
             classGroup.selected === option.id
               ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
               : 'hover:border-slate-300 hover:shadow'

--- a/components/BonomePhase5.vue
+++ b/components/BonomePhase5.vue
@@ -24,8 +24,8 @@
         </header>
 
         <div class="space-y-4">
-          <div v-if="getChoiceOptions(choice).length" class="-mx-1 px-1">
-            <div class="grid grid-flow-col auto-cols-[320px] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+          <div v-if="getChoiceOptions(choice).length">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
               <CardArticle
                 v-for="(opt, optIdx) in getChoiceOptions(choice)"
                 :key="typeof opt.value === 'object' ? optIdx : (opt.value ?? optIdx)"
@@ -35,7 +35,7 @@
                 role="option"
                 :aria-selected="isChoiceOptionSelected(choice, opt)"
                 :class="[
-                  'snap-center focus-within:ring-2 focus-within:ring-blue-500',
+                  'h-full w-full max-w-none focus-within:ring-2 focus-within:ring-blue-500',
                   isChoiceOptionSelected(choice, opt)
                     ? 'ring-2 ring-blue-500 border-blue-500 shadow-md'
                     : 'hover:border-slate-300 hover:shadow',


### PR DESCRIPTION
## Summary
- replace horizontal scrolling card lists with responsive four-column grids in Bonome phases 2, 3, and 5
- align CardArticle usage with the new grid layout while keeping selection, disabled, and badge states intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf115d9a0832a84ca46429e2fc61f